### PR TITLE
[FEAT] 카카오 로그인 API 연동 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ dependencies {
   //jjwt
   implementation("io.jsonwebtoken:jjwt-api:0.11.5")
   runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
-  implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
   //jackson
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,16 @@ dependencies {
   implementation 'org.springframework.data:spring-data-redis:2.7.5'
   implementation 'redis.clients:jedis:3.9.0'
 
+  //jjwt
+  implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+  runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+  implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+  //jackson
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+
+  implementation 'org.yaml:snakeyaml:2.0'
+
   // JSON
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = "fanzip"
+rootProject.name = "fanzip-server"

--- a/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
+++ b/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
@@ -23,7 +23,7 @@ public class OAuthController {
     public ResponseEntity<?> kakaoCallback(@RequestParam String code) throws Exception{
         System.out.println("code:"+code);
         KakaoUserDTO kakaoUser= kakaoOAuthService.login(code);
-        String jwt=jwtProcessor.genereteToken(kakaoUser.getSocialType(),kakaoUser.getSocialId());
+        String jwt=jwtProcessor.generateToken(kakaoUser.getSocialType(),kakaoUser.getSocialId());
 
         if(kakaoUser.isRegistered()){//가입한 유저
             return ResponseEntity.ok().

--- a/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
+++ b/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
@@ -1,0 +1,38 @@
+package org.example.fanzip.auth.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.auth.dto.KakaoUserDTO;
+import org.example.fanzip.auth.service.KakaoOAuthService;
+import org.example.fanzip.auth.jwt.JwtProcessor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+    private final KakaoOAuthService kakaoOAuthService;
+    private final JwtProcessor jwtProcessor;
+
+//    프론트에서 인가코드 전달 (GET /oauth/kakao/callback?code=xxx)
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<?> kakaoCallback(@RequestParam String code) throws Exception{
+        System.out.println("code:"+code);
+        KakaoUserDTO kakaoUser= kakaoOAuthService.login(code);
+        String jwt=jwtProcessor.genereteToken(kakaoUser.getSocialType(),kakaoUser.getSocialId());
+
+        if(kakaoUser.isRegistered()){//가입한 유저
+            return ResponseEntity.ok().
+                    header("Authorization", "Bearer "+jwt)
+                    .body(kakaoUser);
+        }else{//가입하지 않은 사용자
+            return ResponseEntity.status(202)
+                    .header("Authorization", "Bearer "+jwt)
+                    .body(kakaoUser);
+        }
+    }
+}

--- a/src/main/java/org/example/fanzip/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/org/example/fanzip/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,14 @@
+package org.example.fanzip.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class KakaoTokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private int expiresIn;
+    private int refreshTokenExpiresIn;
+}

--- a/src/main/java/org/example/fanzip/auth/dto/KakaoUserDTO.java
+++ b/src/main/java/org/example/fanzip/auth/dto/KakaoUserDTO.java
@@ -1,0 +1,17 @@
+package org.example.fanzip.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class KakaoUserDTO {
+    private String socialType;
+    private String socialId;
+    private String email;
+    private boolean isRegistered;
+}

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
@@ -1,0 +1,45 @@
+package org.example.fanzip.auth.jwt;
+
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final JwtProcessor jwtProcessor;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        System.out.println("jwtInterceptor preHandle");
+
+        String header=request.getHeader("Authorization");
+
+        if(header==null || !header.startsWith("Bearer ")){
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 없습니다.");
+            return false;
+        }
+
+        String token=header.substring(7);
+        System.out.println("token:"+token);
+        try{
+            Jws<Claims> claims= jwtProcessor.parseToken(token);
+
+            System.out.println("claims:"+claims);
+            String socialType=claims.getBody().get("socialType", String.class);
+            String socialId=claims.getBody().get("socialId", String.class);
+            request.setAttribute("socialType",socialType);
+            request.setAttribute("socialId",socialId);
+
+            return true;
+        }catch (JwtException e){
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
@@ -31,7 +31,7 @@ public class JwtProcessor {
 //    private Key key=Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 //    private Key key=Keys.secretKeyFor(SignatureAlgorithm.HS256);
     //JWT 생성
-    public String genereteToken(String socialType, String socialId){
+    public String generateToken(String socialType, String socialId){
 //        System.out.println("key:"+key);
 
         return Jwts.builder()

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
@@ -1,0 +1,72 @@
+package org.example.fanzip.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProcessor {
+    static private final long TOKEN_VALID_MILISECOND=1000L*60*5;
+
+
+
+    private final Key key;
+
+    public JwtProcessor(@Value("${jwt.secret}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+//    @Value("${jwt.secret}")
+//    private String secretKey;
+
+//    private String secretKey="SuperSecretKeyForJWTSigning123!@#";
+//    private Key key=Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+//    private Key key=Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    //JWT 생성
+    public String genereteToken(String socialType, String socialId){
+//        System.out.println("key:"+key);
+
+        return Jwts.builder()
+//                .setSubject(socialType+":"+socialId)
+                .claim("socialType",socialType)
+                .claim("socialId",socialId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(new Date().getTime()+TOKEN_VALID_MILISECOND))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    public Jws<Claims> parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    //JWT Subject(username) 추출
+    public String getUsername(String token){
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+    //JWT 검증(유효 기간 검증)-해석 불가인 경우 예외 발생
+    public boolean validateToken(String token){
+        Jws<Claims> claims=Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+        return true;
+    }
+}

--- a/src/main/java/org/example/fanzip/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/example/fanzip/auth/service/KakaoOAuthService.java
@@ -1,0 +1,127 @@
+package org.example.fanzip.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.auth.dto.KakaoTokenResponse;
+import org.example.fanzip.auth.dto.KakaoUserDTO;
+import org.example.fanzip.user.dto.UserDTO;
+import org.example.fanzip.user.service.UserService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthService {
+
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+
+    @Override
+    public KakaoUserDTO login(String code) throws Exception {
+        KakaoTokenResponse info=requestAccessToken(code);
+        JsonNode profile=requestUserInfo(info.getAccessToken());
+
+        String socialType="kakao";
+        String socialId=profile.get("id").asText();
+
+        JsonNode kakaoAccountNode=profile.path("kakao_account");
+        String email=kakaoAccountNode.get("email").asText(null);
+        System.out.println("email:"+email);
+
+        UserDTO user=userService.findBySocialTypeAndSocialId(socialType,socialId);
+
+        boolean isRegistered=(user!=null);
+
+        return KakaoUserDTO.builder()
+                .socialType(socialType)
+                .socialId(socialId)
+                .email(email)
+                .isRegistered(isRegistered)
+                .build();
+    }
+//    private KakaoTokenResponse refreshAccessToken(String socialId) throws IOException {
+//        String tokenUrl="https://kauth.kakao.com/oauth/token";
+//
+//        String refreshToken=userService.getRefreshtoken("kakao", socialId);
+//        if(refreshToken==null){throw new IllegalStateException("No refresh token found");}
+//
+//        RestTemplate restTemplate = new RestTemplate();
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+//
+//        MultiValueMap<String, String> params=new LinkedMultiValueMap<>();
+//        params.add("grant_type","refresh_token");
+//        params.add("client_id",clientId);
+//        params.add("refresh_token",refreshToken);
+//
+//        HttpEntity<MultiValueMap<String, String>> request=new HttpEntity<>(params,headers);
+//        ResponseEntity<String> response=restTemplate.postForEntity(tokenUrl,request,String.class);
+//
+//        JsonNode node=objectMapper.readTree(response.getBody());
+//        String newAccessToken=node.get("access_token").asText();
+//
+//        if(node.has("refresh_token")){
+//            String newRefreshToken=node.get("refresh_token").asText();
+//            userService.updateRefreshToken("kakao", newRefreshToken);
+//        }
+//        return newAccessToken;
+//    }
+
+    private KakaoTokenResponse requestAccessToken(String code) throws IOException {
+        String tokenUrl="https://kauth.kakao.com/oauth/token";
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params=new LinkedMultiValueMap<>();
+        params.add("grant_type","authorization_code");
+        params.add("client_id",clientId);
+        params.add("redirect_uri",redirectUri);
+        params.add("code",code);
+
+        HttpEntity<MultiValueMap<String, String>> request=new HttpEntity<>(params,headers);
+        ResponseEntity<String> response=restTemplate.postForEntity(tokenUrl,request,String.class);
+
+        JsonNode node=objectMapper.readTree(response.getBody());
+        System.out.println("카카오 응답 JSON: " + node.toPrettyString());
+
+        return new KakaoTokenResponse(
+                node.get("access_token").asText(),
+                node.has("refresh_token")?node.get("refresh_token").asText():null,
+                node.get("expires_in").asInt(),
+                node.has("refresh_token_expires_in")?node.get("refresh_token_expires_in").asInt():0
+        );
+    }
+
+    private JsonNode requestUserInfo(String accessToken) throws IOException {
+        String url="https://kapi.kakao.com/v2/user/me";
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request=new HttpEntity<>(headers);
+        ResponseEntity<String> response=restTemplate.exchange(
+            url, HttpMethod.GET,request,String.class
+        );
+
+        JsonNode node=objectMapper.readTree(response.getBody());
+        System.out.println("node: " + node.toPrettyString());
+        return node;
+    }
+}

--- a/src/main/java/org/example/fanzip/auth/service/OAuthService.java
+++ b/src/main/java/org/example/fanzip/auth/service/OAuthService.java
@@ -1,0 +1,9 @@
+package org.example.fanzip.auth.service;
+
+import org.example.fanzip.auth.dto.KakaoUserDTO;
+
+import java.io.IOException;
+
+public interface OAuthService {
+    KakaoUserDTO login(String code) throws Exception;
+}

--- a/src/main/java/org/example/fanzip/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/config/RootConfig.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -18,21 +19,19 @@ import javax.sql.DataSource;
 
 @Configuration
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
-@MapperScan(basePackages = {"org.example.fanzip.payment.mapper"})
-@ComponentScan(basePackages = {"org.example.fanzip.payment"})
+@MapperScan(basePackages = {
+        "org.example.fanzip.user.mapper",
+        "org.example.fanzip.payment.mapper"})
+@ComponentScan(basePackages = {
+        "org.example.fanzip",
+        "org.example.fanzip.user.service",
+        "org.example.fanzip.payment"
+})
 public class RootConfig {
-
-    @Value("${spring.datasource.driver-class-name}")
-    private String driver;
-
-    @Value("${spring.datasource.url}")
-    private String url;
-
-    @Value("${spring.datasource.username}")
-    private String username;
-
-    @Value("${spring.datasource.password}")
-    private String password;
+    @Value("${spring.datasource.driver-class-name}") String driver;
+    @Value("${spring.datasource.url}") String url;
+    @Value("${spring.datasource.username}") String username;
+    @Value("${spring.datasource.password}") String password;
 
 
     @Bean
@@ -62,5 +61,10 @@ public class RootConfig {
     public DataSourceTransactionManager transactionManager(){
         DataSourceTransactionManager manager = new DataSourceTransactionManager(dataSource());
         return manager;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/main/java/org/example/fanzip/config/ServletConfig.java
+++ b/src/main/java/org/example/fanzip/config/ServletConfig.java
@@ -1,9 +1,12 @@
 package org.example.fanzip.config;
 
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.auth.jwt.JwtInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.servlet.config.annotation.*;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -16,8 +19,17 @@ import org.springframework.web.servlet.view.JstlView;
 import java.util.List;
 
 @EnableWebMvc
-@ComponentScan(basePackages = {"org.example.fanzip"})
+@ComponentScan(basePackages = {
+        "org.example.fanzip.controller",
+        "org.example.fanzip.auth.controller",
+        "org.example.fanzip.user.controller",
+        "org.example.fanzip"
+})
+@RequiredArgsConstructor
 public class ServletConfig implements WebMvcConfigurer {
+
+    private final JwtInterceptor jwtInterceptor;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
@@ -33,6 +45,13 @@ public class ServletConfig implements WebMvcConfigurer {
         bean.setPrefix("/WEB-INF/views/");
         bean.setSuffix(".jsp");
         registry.viewResolver(bean);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/oauth/**", "/resources/**");
     }
 
     @Override

--- a/src/main/java/org/example/fanzip/controller/HomeController.java
+++ b/src/main/java/org/example/fanzip/controller/HomeController.java
@@ -10,6 +10,6 @@ public class HomeController {
     @GetMapping("/")
     public String home() {
         log.info("================> HomeController /");
-        return "index";
+        return "login";
     }
 }

--- a/src/main/java/org/example/fanzip/user/controller/UserController.java
+++ b/src/main/java/org/example/fanzip/user/controller/UserController.java
@@ -1,0 +1,25 @@
+package org.example.fanzip.user.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.user.dto.AdditionalInfoDTO;
+import org.example.fanzip.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody AdditionalInfoDTO additionalInfoDTO){
+        userService.register(additionalInfoDTO);
+        return ResponseEntity.ok("sign up success!!");
+    }
+}

--- a/src/main/java/org/example/fanzip/user/dto/AdditionalInfoDTO.java
+++ b/src/main/java/org/example/fanzip/user/dto/AdditionalInfoDTO.java
@@ -1,0 +1,20 @@
+package org.example.fanzip.user.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+
+public class AdditionalInfoDTO {
+    private String socialType;
+    private String socialId;
+    private String email;
+    private String name;
+    private String phone;
+}

--- a/src/main/java/org/example/fanzip/user/dto/UserDTO.java
+++ b/src/main/java/org/example/fanzip/user/dto/UserDTO.java
@@ -1,0 +1,34 @@
+package org.example.fanzip.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class UserDTO {
+    private Long userId;
+    private String email;
+    private String name;
+
+    private String phone;
+
+    private String socialType;
+    private String socialId;
+
+    private String address1;
+    private String address2;
+    private String zipcode;
+    private String recipientName;
+    private String recipientPhone;
+
+    private Date created_at;
+    private Date updated_at;
+    private Date deleted_at;
+}

--- a/src/main/java/org/example/fanzip/user/mapper/UserMapper.java
+++ b/src/main/java/org/example/fanzip/user/mapper/UserMapper.java
@@ -1,0 +1,13 @@
+package org.example.fanzip.user.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.example.fanzip.user.dto.UserDTO;
+
+public interface UserMapper {
+    UserDTO findBySocialTypeAndSocialId(@Param("socialType") String socialType,
+                                        @Param("socialId") String socialId);
+    void insertUser(UserDTO user);
+//    void updateAdditionalInfo(@Param("socialType") String socialType,
+//                              @Param("socialId") String socialId,
+//                              @Param("additionalInfoDTO") AdditionalInfoDTO additionalInfoDTO);
+}

--- a/src/main/java/org/example/fanzip/user/service/UserService.java
+++ b/src/main/java/org/example/fanzip/user/service/UserService.java
@@ -1,0 +1,36 @@
+package org.example.fanzip.user.service;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.user.dto.AdditionalInfoDTO;
+import org.example.fanzip.user.dto.UserDTO;
+import org.example.fanzip.user.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+    private final UserMapper mapper;
+
+    public UserDTO findBySocialTypeAndSocialId(String socialType, String socialId){
+        return mapper.findBySocialTypeAndSocialId(socialType, socialId);
+    }
+    public void register(AdditionalInfoDTO dto){
+        UserDTO newUser=UserDTO.builder()
+                .socialType(dto.getSocialType())
+                .socialId(dto.getSocialId())
+                .name(dto.getName())
+                .phone(dto.getPhone())
+                .email(dto.getEmail())
+                .created_at(new Date())
+                .build();
+        mapper.insertUser(newUser);
+    }
+//    void updateAdditionalInfo(String socialType, String socialId, AdditionalInfoDTO additionalInfoDTO){
+//        mapper.updateAdditionalInfo(socialType, socialId, additionalInfoDTO);
+//    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/testdb
-    username: root
-    password: 003816
+    url: jdbc:mysql://127.0.0.1:3306/scoula_db
+    username: scoula
+    password: 12345678
 
   redis:
     host: ${REDIS_HOST:localhost}
@@ -15,3 +15,11 @@ mybatis:
   type-aliases-package: org.example.fanzip.payment.dto
   configuration:
     map-underscore-to-camel-case: true
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: http://localhost:5173/oauth/kakao/callback
+

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -3,6 +3,9 @@
         PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-config.dtd">
 <configuration>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true"/>
+    </settings>
     <typeAliases>
         <typeAlias alias="Payments" type="org.example.fanzip.payment.domain.Payments"></typeAlias>
     </typeAliases>

--- a/src/main/resources/org/example/fanzip/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/example/fanzip/user/mapper/UserMapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.example.fanzip.user.mapper.UserMapper">
+    <insert id="insertUser">
+        insert into Users
+            (social_type, social_id, name, phone, email)
+        values (#{socialType}, #{socialId}, #{name}, #{phone}, #{email})
+    </insert>
+    <update id="updateAdditionalInfo">
+        update Users
+        set name=#{additionalInfoDTO.name},
+            phone=#{additionalInfoDTO.phone},
+            email=#{additionalInfoDTO.email},
+            updated_at=current_timestamp
+        where social_type=#{socialType} and social_id=#{socialId}
+    </update>
+
+    <select id="findBySocialTypeAndSocialId" resultType="org.example.fanzip.user.dto.UserDTO">
+        select * from Users
+                 where social_type=#{socialType} and social_id=#{socialId}
+    </select>
+</mapper>
+

--- a/src/main/webapp/WEB-INF/views/additionalInfo.jsp
+++ b/src/main/webapp/WEB-INF/views/additionalInfo.jsp
@@ -1,0 +1,16 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: kimseyeon
+  Date: 25. 7. 23.
+  Time: 오전 12:00
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,0 +1,16 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>카카오 로그인 테스트</title>
+</head>
+<body>
+<h2>카카오 로그인 테스트</h2>
+
+<a href="https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=a44e43a01d421616a3292cd7194f2d22&redirect_uri=http://localhost:8080/oauth/kakao/callback">
+  <img src="https://developers.kakao.com/assets/img/about/logos/kakaologin/kr/kakao_account_login_btn_medium_narrow.png"
+       alt="카카오 로그인 버튼" />
+</a>
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main.jsp
@@ -1,0 +1,16 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: kimseyeon
+  Date: 25. 7. 22.
+  Time: 오후 5:35
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+    메인 페이지
+</body>
+</html>

--- a/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
+++ b/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
@@ -1,0 +1,49 @@
+package org.example.fanzip.auth.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.config.RootConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Slf4j
+class JwtProcessorTest {
+
+    @Autowired
+    JwtProcessor jwtProcessor;
+
+    @Test
+    void genereteToken() {
+        String socialType="kakao";
+        String socialId="1234";
+        String jwt=jwtProcessor.genereteToken(socialType,socialId);
+        log.info("jwt:{}",jwt);
+        assertNotNull(jwt);
+//        String token= jwtProcessor.genereteToken(username);
+//        log.info(token);
+//        assertNotNull(token);
+    }
+
+    @Test
+    void getUsername() {
+        String token="eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJrYWthbzoxMjM0IiwiaWF0IjoxNzUzMTY5NTEwLCJleHAiOjE3NTMxNjk4MTB9.KXplQCNqaK6r4UbAfpdTd9clTRE6T3HCeo8BdsRQ3cNsO1joHky5o8uQIxmdThe6";
+        String username=jwtProcessor.getUsername(token);
+        log.info(username);
+        assertNotNull(username);
+    }
+
+    @Test
+    void validateToken() {
+        String token="eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJ1c2VyMCIsImlhdCI6MTc1MzA3ODg1OCwiZXhwIjoxNzUzMDc5MTU4fQ.K1OUzZ6tk2g8bs8A6S_XtIQ8SASH_ZMy1Nk-YyxbiVHMzqLlQGhf3J7fKYjHGV-9";
+
+        boolean isValid=jwtProcessor.validateToken(token);
+//        log.info(isValid);
+        assertTrue(isValid);
+    }
+}

--- a/src/test/java/org/example/fanzip/user/mapper/UserMapperTest.java
+++ b/src/test/java/org/example/fanzip/user/mapper/UserMapperTest.java
@@ -1,0 +1,55 @@
+package org.example.fanzip.user.mapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.config.RootConfig;
+import org.example.fanzip.user.dto.AdditionalInfoDTO;
+import org.example.fanzip.user.dto.UserDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Slf4j
+class UserMapperTest {
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    void findBySocialTypeAndSocialId() {
+        UserDTO userDTO = userMapper.findBySocialTypeAndSocialId("kakao", "12345");
+        log.info("userDTO={}", userDTO);
+        assertNotNull(userDTO);
+    }
+
+    @Test
+    void insertUser() {
+        UserDTO userDTO = UserDTO.builder()
+                .socialType("kakao")
+                .socialId("123456")
+                .created_at(new Date())
+                .build();
+        userMapper.insertUser(userDTO);
+
+    }
+
+    @Test
+    void updateAdditionalInfo() {
+//        AdditionalInfoDTO additionalInfoDTO = AdditionalInfoDTO.builder()
+//                .name("HongGilDong")
+//                .phone("010-1234-5678")
+//                .email("HongGilDong@gmail.com")
+//                .build();
+//        userMapper.updateAdditionalInfo("kakao", "12345",additionalInfoDTO);
+//        UserDTO userDTO = userMapper.findBySocialTypeAndSocialId("kakao", "12345");
+//        assertNotNull(userDTO);
+    }
+}

--- a/src/test/java/org/example/fanzip/user/service/UserServiceTest.java
+++ b/src/test/java/org/example/fanzip/user/service/UserServiceTest.java
@@ -1,0 +1,50 @@
+package org.example.fanzip.user.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.config.RootConfig;
+import org.example.fanzip.user.dto.AdditionalInfoDTO;
+import org.example.fanzip.user.dto.UserDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Slf4j
+class UserServiceTest {
+
+    @Autowired
+    private UserService service;
+
+    @Test
+    void findBySocialTypeAndSocialId() {
+        UserDTO userDTO = service.findBySocialTypeAndSocialId("kakao", "1234567");
+        log.info("userDTO={}", userDTO);
+        assertNotNull(userDTO);
+    }
+
+    @Test
+    void registerUser() {
+//        String socialType="kakao";
+//        String socialId="123456";
+//        service.loginOrRegister(socialType,socialId,null);
+
+    }
+
+    @Test
+    void updateAdditionalInfo() {
+//        AdditionalInfoDTO additionalInfoDTO = AdditionalInfoDTO.builder()
+//                .name("yonseeee")
+//                .phone("010-1234-5678")
+//                .email("yonseee@gmail.com")
+//                .build();
+//        service.updateAdditionalInfo("kakao","1234567", additionalInfoDTO);
+    }
+}

--- a/users.sql
+++ b/users.sql
@@ -1,0 +1,26 @@
+drop table if exists Users;
+create table Users(
+    user_id bigint auto_increment PRIMARY KEY,
+    email VARCHAR(255) unique,
+    name VARCHAR(100),
+
+    phone VARCHAR(20),
+
+    social_type VARCHAR(20) NOT NULL,
+    social_id VARCHAR(100) NOT NULL,
+
+    address1 VARCHAR(255),
+    address2 VARCHAR(255),
+    zipcode VARCHAR(20),
+    recipient_name VARCHAR(100),
+    recipient_phone VARCHAR(20),
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+
+    UNIQUE KEY uq_social_user(social_type,social_id)
+
+);
+
+select * from Users;

--- a/users.sql
+++ b/users.sql
@@ -1,13 +1,11 @@
 drop table if exists Users;
 create table Users(
     user_id bigint auto_increment PRIMARY KEY,
-    email VARCHAR(255) unique,
+    email VARCHAR(255) not null unique,
     name VARCHAR(100),
-
     phone VARCHAR(20),
-
-    social_type VARCHAR(20) NOT NULL,
-    social_id VARCHAR(100) NOT NULL,
+    social_type VARCHAR(20),
+    social_id VARCHAR(100),
 
     address1 VARCHAR(255),
     address2 VARCHAR(255),
@@ -21,6 +19,6 @@ create table Users(
 
     UNIQUE KEY uq_social_user(social_type,social_id)
 
-);
+)ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 select * from Users;


### PR DESCRIPTION
- 제목 : feat(#19 ): 카카오 로그인 API 구현  


## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용


-Kakao OAuth 인가 코드 받기 구현 (/oauth/kakao/callback)
-Kakao AccessToken 요청 및 사용자 정보 조회 구현
-Jwt 토큰 생성 및 반환 처리
-기존 사용자 여부 확인(DB 조회)
-신규 사용자일 경우 추가 정보 입력 필요 응답(202 응답 처리)
-JWT 기반 인증 인터셉터 구현 및 /api/** 경로 보호
-사용자 정보 DB 저장 로직 구현(UserService, UserMapper)
-카카오 로그인 테스트용 JSP 페이지 작성
-로그인 이후 flow: 가입된 유저인지 판별 후 분기 처리

<br/>

## ➕ 이슈 링크

- Closes #19 

<br/>

## 📸 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 📬 전달 사항

- 카카오 인증 성공 후 추가 정보(이름,전화번호) 기입해야 회원가입 완료 => post man으로 테스트 가능

<br/>

## 🔧 앞으로의 과제

- access token, refresh token 로컬 스토리지에서 관리하는 방식으로 처리
- 카카오 로그아웃, 탈퇴
- 네이버 api 연동