### PR TITLE
[feat] JWT 수정 - socialType, socialId 삭제, userId추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
   //jjwt
   implementation("io.jsonwebtoken:jjwt-api:0.11.5")
   runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+  runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
   //jackson
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'

--- a/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
+++ b/src/main/java/org/example/fanzip/auth/controller/OAuthController.java
@@ -23,16 +23,16 @@ public class OAuthController {
     public ResponseEntity<?> kakaoCallback(@RequestParam String code) throws Exception{
         System.out.println("code:"+code);
         KakaoUserDTO kakaoUser= kakaoOAuthService.login(code);
-        String jwt=jwtProcessor.generateToken(kakaoUser.getSocialType(),kakaoUser.getSocialId());
 
         if(kakaoUser.isRegistered()){//가입한 유저
+            String jwt=jwtProcessor.generateToken(kakaoUser.getUserId());
             return ResponseEntity.ok().
                     header("Authorization", "Bearer "+jwt)
                     .body(kakaoUser);
         }else{//가입하지 않은 사용자
             return ResponseEntity.status(202)
-                    .header("Authorization", "Bearer "+jwt)
                     .body(kakaoUser);
         }
+
     }
 }

--- a/src/main/java/org/example/fanzip/auth/dto/KakaoUserDTO.java
+++ b/src/main/java/org/example/fanzip/auth/dto/KakaoUserDTO.java
@@ -13,5 +13,6 @@ public class KakaoUserDTO {
     private String socialType;
     private String socialId;
     private String email;
+    private Long userId;
     private boolean isRegistered;
 }

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
@@ -31,8 +31,8 @@ public class JwtInterceptor implements HandlerInterceptor {
             Jws<Claims> claims= jwtProcessor.parseToken(token);
 
             System.out.println("claims:"+claims);
-            String userID=claims.getBody().get("userID", String.class);
-            request.setAttribute("userID", userID);
+            String userId=claims.getBody().get("userId", String.class);
+            request.setAttribute("userId", userId);
             return true;
         }catch (JwtException e){
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtInterceptor.java
@@ -31,11 +31,8 @@ public class JwtInterceptor implements HandlerInterceptor {
             Jws<Claims> claims= jwtProcessor.parseToken(token);
 
             System.out.println("claims:"+claims);
-            String socialType=claims.getBody().get("socialType", String.class);
-            String socialId=claims.getBody().get("socialId", String.class);
-            request.setAttribute("socialType",socialType);
-            request.setAttribute("socialId",socialId);
-
+            String userID=claims.getBody().get("userID", String.class);
+            request.setAttribute("userID", userID);
             return true;
         }catch (JwtException e){
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
@@ -1,9 +1,6 @@
 package org.example.fanzip.auth.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import io.jsonwebtoken.security.Keys;
@@ -14,9 +11,7 @@ import java.util.Date;
 
 @Component
 public class JwtProcessor {
-    static private final long TOKEN_VALID_MILISECOND=1000L*60*5;
-
-
+    static private final long TOKEN_VALID_MILISECOND=1000L*60*30;
 
     private final Key key;
 
@@ -24,24 +19,18 @@ public class JwtProcessor {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-//    @Value("${jwt.secret}")
-//    private String secretKey;
-
-//    private String secretKey="SuperSecretKeyForJWTSigning123!@#";
-//    private Key key=Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-//    private Key key=Keys.secretKeyFor(SignatureAlgorithm.HS256);
     //JWT 생성
-    public String generateToken(String socialType, String socialId){
-//        System.out.println("key:"+key);
-
-        return Jwts.builder()
-//                .setSubject(socialType+":"+socialId)
-                .claim("socialType",socialType)
-                .claim("socialId",socialId)
+    public String generateToken(Long userId) {
+        JwtBuilder builder= Jwts.builder()
+                .claim("userId", userId)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(new Date().getTime()+TOKEN_VALID_MILISECOND))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+                .signWith(key, SignatureAlgorithm.HS256);
+
+        if(userId!=null){
+            builder.claim("userId",userId);
+        }
+        return builder.compact();
     }
 
 
@@ -53,13 +42,13 @@ public class JwtProcessor {
     }
 
     //JWT Subject(username) 추출
-    public String getUsername(String token){
+    public String getUserId(String token){
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .getSubject();
+                .get("userId").toString();
     }
     //JWT 검증(유효 기간 검증)-해석 불가인 경우 예외 발생
     public boolean validateToken(String token){

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
@@ -41,13 +41,13 @@ public class JwtProcessor {
     }
 
     //JWT Subject(username) 추출
-    public String getUserId(String token){
+    public Long getUserId(String token){
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .get("userId").toString();
+                .get("userId",Long.class);
     }
     //JWT 검증(유효 기간 검증)-해석 불가인 경우 예외 발생
     public boolean validateToken(String token){

--- a/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
+++ b/src/main/java/org/example/fanzip/auth/jwt/JwtProcessor.java
@@ -22,7 +22,6 @@ public class JwtProcessor {
     //JWT 생성
     public String generateToken(Long userId) {
         JwtBuilder builder= Jwts.builder()
-                .claim("userId", userId)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(new Date().getTime()+TOKEN_VALID_MILISECOND))
                 .signWith(key, SignatureAlgorithm.HS256);

--- a/src/main/java/org/example/fanzip/auth/service/KakaoOAuthService.java
+++ b/src/main/java/org/example/fanzip/auth/service/KakaoOAuthService.java
@@ -45,12 +45,14 @@ public class KakaoOAuthService implements OAuthService {
         UserDTO user=userService.findBySocialTypeAndSocialId(socialType,socialId);
 
         boolean isRegistered=(user!=null);
+        Long userId=isRegistered?user.getUserId():null;
 
         return KakaoUserDTO.builder()
                 .socialType(socialType)
                 .socialId(socialId)
                 .email(email)
                 .isRegistered(isRegistered)
+                .userId(userId)
                 .build();
     }
 //    private KakaoTokenResponse refreshAccessToken(String socialId) throws IOException {

--- a/src/main/java/org/example/fanzip/config/ServletConfig.java
+++ b/src/main/java/org/example/fanzip/config/ServletConfig.java
@@ -51,7 +51,7 @@ public class ServletConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/oauth/**", "/resources/**");
+                .excludePathPatterns("/oauth/**", "/resources/**","/api/users/**");
     }
 
     @Override

--- a/src/main/java/org/example/fanzip/user/controller/UserController.java
+++ b/src/main/java/org/example/fanzip/user/controller/UserController.java
@@ -2,6 +2,7 @@ package org.example.fanzip.user.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.example.fanzip.auth.jwt.JwtProcessor;
 import org.example.fanzip.user.dto.AdditionalInfoDTO;
 import org.example.fanzip.user.service.UserService;
 import org.springframework.http.ResponseEntity;
@@ -16,10 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final JwtProcessor jwtProcessor;
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody AdditionalInfoDTO additionalInfoDTO){
-        userService.register(additionalInfoDTO);
-        return ResponseEntity.ok("sign up success!!");
+        Long userId=userService.register(additionalInfoDTO);
+        System.out.println(userId);
+        String jwt=jwtProcessor.generateToken(userId);
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer "+jwt)
+                .body("sign up successful");
     }
 }

--- a/src/main/java/org/example/fanzip/user/service/UserService.java
+++ b/src/main/java/org/example/fanzip/user/service/UserService.java
@@ -19,7 +19,7 @@ public class UserService {
     public UserDTO findBySocialTypeAndSocialId(String socialType, String socialId){
         return mapper.findBySocialTypeAndSocialId(socialType, socialId);
     }
-    public void register(AdditionalInfoDTO dto){
+    public Long register(AdditionalInfoDTO dto){
         UserDTO newUser=UserDTO.builder()
                 .socialType(dto.getSocialType())
                 .socialId(dto.getSocialId())
@@ -29,6 +29,8 @@ public class UserService {
                 .created_at(new Date())
                 .build();
         mapper.insertUser(newUser);
+        System.out.println("userId: "+newUser.getUserId());
+        return newUser.getUserId();
     }
 //    void updateAdditionalInfo(String socialType, String socialId, AdditionalInfoDTO additionalInfoDTO){
 //        mapper.updateAdditionalInfo(socialType, socialId, additionalInfoDTO);

--- a/src/main/resources/org/example/fanzip/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/example/fanzip/user/mapper/UserMapper.xml
@@ -7,6 +7,9 @@
         insert into Users
             (social_type, social_id, name, phone, email)
         values (#{socialType}, #{socialId}, #{name}, #{phone}, #{email})
+        <selectKey resultType="Long" keyProperty="userId" keyColumn="user_id" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
     </insert>
     <update id="updateAdditionalInfo">
         update Users

--- a/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
+++ b/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
@@ -20,30 +20,23 @@ class JwtProcessorTest {
 
     @Test
     void genereteToken() {
-        String socialType="kakao";
-        String socialId="1234";
-        String jwt=jwtProcessor.genereteToken(socialType,socialId);
+        String jwt=jwtProcessor.generateToken(3L);
         log.info("jwt:{}",jwt);
         assertNotNull(jwt);
-//        String token= jwtProcessor.genereteToken(username);
-//        log.info(token);
-//        assertNotNull(token);
     }
 
     @Test
-    void getUsername() {
-        String token="eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJrYWthbzoxMjM0IiwiaWF0IjoxNzUzMTY5NTEwLCJleHAiOjE3NTMxNjk4MTB9.KXplQCNqaK6r4UbAfpdTd9clTRE6T3HCeo8BdsRQ3cNsO1joHky5o8uQIxmdThe6";
-        String username=jwtProcessor.getUsername(token);
-        log.info(username);
-        assertNotNull(username);
+    void getUserId() {
+        String token= "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjksImlhdCI6MTc1MzMzMDQ1NSwiZXhwIjoxNzUzMzMyMjU1fQ.xrCrKujMwXBNo9Fk3C3j8KxBxWMoA6prkomxcTI3Qr4";
+        String userId=jwtProcessor.getUserId(token);
+        log.info("userId:{}",userId);
+        assertNotNull(userId);
     }
 
     @Test
     void validateToken() {
         String token="eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJ1c2VyMCIsImlhdCI6MTc1MzA3ODg1OCwiZXhwIjoxNzUzMDc5MTU4fQ.K1OUzZ6tk2g8bs8A6S_XtIQ8SASH_ZMy1Nk-YyxbiVHMzqLlQGhf3J7fKYjHGV-9";
-
         boolean isValid=jwtProcessor.validateToken(token);
-//        log.info(isValid);
         assertTrue(isValid);
     }
 }

--- a/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
+++ b/src/test/java/org/example/fanzip/auth/jwt/JwtProcessorTest.java
@@ -28,7 +28,7 @@ class JwtProcessorTest {
     @Test
     void getUserId() {
         String token= "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjksImlhdCI6MTc1MzMzMDQ1NSwiZXhwIjoxNzUzMzMyMjU1fQ.xrCrKujMwXBNo9Fk3C3j8KxBxWMoA6prkomxcTI3Qr4";
-        String userId=jwtProcessor.getUserId(token);
+        Long userId=jwtProcessor.getUserId(token);
         log.info("userId:{}",userId);
         assertNotNull(userId);
     }


### PR DESCRIPTION
## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용

- KakaoUserDTO 수정 - userId 필드 추가
- DB에 insertUser후 자동 생성된 userId 가져오기(selectKey 문 사용)
- 회원가입 시 userId 반환 및 JWT 발급(추가정보까지 입력했을 때)
- 로그인 시 userId 반환 및 JWT 발급
- 
<br/>

## ➕ 이슈 링크

- Closes #27 

<br/>

## 📸 이미지 첨부


<br/>

## 📬 전달 사항

<userId 사용법>
JwtProcessor 주입
String userId=jwtProcessor.getUserId(token);

<br/>

## 🔧 앞으로의 과제

- 카카오 로그아웃, 탈퇴
- 프론트 연동
- accesstoken, refreshtoken