### PR TITLE
[feat] 팬 카드 API 및 공통 설정 구축

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="ms-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="ms-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group 'org.example'
 version '1.0-SNAPSHOT'
 
+war {
+    archiveFileName = 'fanzip-1.0-SNAPSHOT.war'
+}
+
 repositories {
   mavenCentral()
 }
@@ -29,6 +33,7 @@ dependencies {
           { exclude group: 'commons-logging', module: 'commons-logging' }
   implementation "org.springframework:spring-webmvc:${springVersion}"
   implementation 'javax.inject:javax.inject:1'
+  implementation 'org.yaml:snakeyaml:1.33'
 
   // Servlet
   compileOnly('javax.servlet:javax.servlet-api:4.0.1')
@@ -65,6 +70,7 @@ dependencies {
   testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
   testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
   testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+  implementation 'com.h2database:h2:2.1.214'
   testImplementation 'org.assertj:assertj-core:3.24.2'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.springframework:spring-test:5.3.30'
@@ -74,6 +80,16 @@ dependencies {
   //Redis
   implementation 'org.springframework.data:spring-data-redis:2.7.5'
   implementation 'redis.clients:jedis:3.9.0'
+
+  // Jackson (required for Swagger)
+  implementation 'com.fasterxml.jackson.core:jackson-core:2.13.5'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+  implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.5'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5'
+
+  // Swagger
+  implementation 'io.springfox:springfox-swagger2:2.9.2'
+  implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
   //jjwt
   implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/src/main/java/org/example/fanzip/config/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/fanzip/config/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.example.fanzip.config;
+
+import org.example.fanzip.fancard.exception.FancardNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(FancardNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleFancardNotFoundException(FancardNotFoundException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.NOT_FOUND.value());
+        body.put("error", "Not Found");
+        body.put("message", ex.getMessage());
+        
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/fanzip/config/JacksonConfig.java
+++ b/src/main/java/org/example/fanzip/config/JacksonConfig.java
@@ -1,0 +1,46 @@
+package org.example.fanzip.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Configuration
+public class JacksonConfig implements WebMvcConfigurer {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        JavaTimeModule module = new JavaTimeModule();
+        
+        module.addSerializer(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
+        module.addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        module.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
+
+        return new ObjectMapper()
+                .registerModule(module)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper());
+        converters.add(0, converter);
+    }
+}

--- a/src/main/java/org/example/fanzip/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/config/RootConfig.java
@@ -1,6 +1,7 @@
 package org.example.fanzip.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -18,8 +19,11 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import javax.sql.DataSource;
 
 @Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+@ComponentScan(basePackages = {"org.example.fanzip"}, excludeFilters = @ComponentScan.Filter(org.springframework.stereotype.Controller.class))
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
 @MapperScan(basePackages = {
+        "org.example.fanzip.fancard.mapper"
         "org.example.fanzip.user.mapper",
         "org.example.fanzip.payment.mapper",
         "org.example.fanzip.market.mapper",
@@ -60,10 +64,11 @@ public class RootConfig {
         SqlSessionFactoryBean sqlSessionFactory = new SqlSessionFactoryBean();
         sqlSessionFactory.setConfigLocation(
                 applicationContext.getResource("classpath:/mybatis-config.xml"));
+        sqlSessionFactory.setMapperLocations(
+                applicationContext.getResources("classpath:/mappers/*.xml"));
         sqlSessionFactory.setDataSource(dataSource());
         return (SqlSessionFactory) sqlSessionFactory.getObject();
     }
-
     @Bean
     public DataSourceTransactionManager transactionManager(){
         DataSourceTransactionManager manager = new DataSourceTransactionManager(dataSource());

--- a/src/main/java/org/example/fanzip/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/config/RootConfig.java
@@ -23,7 +23,7 @@ import javax.sql.DataSource;
 @ComponentScan(basePackages = {"org.example.fanzip"}, excludeFilters = @ComponentScan.Filter(org.springframework.stereotype.Controller.class))
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
 @MapperScan(basePackages = {
-        "org.example.fanzip.fancard.mapper"
+        "org.example.fanzip.fancard.mapper",
         "org.example.fanzip.user.mapper",
         "org.example.fanzip.payment.mapper",
         "org.example.fanzip.market.mapper",

--- a/src/main/java/org/example/fanzip/config/ServletConfig.java
+++ b/src/main/java/org/example/fanzip/config/ServletConfig.java
@@ -9,16 +9,18 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.servlet.config.annotation.*;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
-
 import java.util.List;
 
+@Configuration
 @EnableWebMvc
+@ComponentScan(basePackages = {"org.example.fanzip.controller", "org.example.fanzip.fancard.controller"})
 @ComponentScan(basePackages = {
         "org.example.fanzip.controller",
         "org.example.fanzip.auth.controller",
@@ -37,6 +39,12 @@ public class ServletConfig implements WebMvcConfigurer {
         registry
                 .addResourceHandler("/resources/**")
                 .addResourceLocations("/resources/");
+
+        // Swagger UI 리소스 추가
+        registry.addResourceHandler("swagger-ui.html")
+                .addResourceLocations("classpath:/META-INF/resources/");
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
 
     // jsp view resolver 설정

--- a/src/main/java/org/example/fanzip/config/SwaggerConfig.java
+++ b/src/main/java/org/example/fanzip/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package org.example.fanzip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("org.example.fanzip"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Fanzip API")
+                .description("Fanzip 서비스 API 문서")
+                .version("1.0")
+                .build();
+    }
+}

--- a/src/main/java/org/example/fanzip/config/YamlPropertySourceFactory.java
+++ b/src/main/java/org/example/fanzip/config/YamlPropertySourceFactory.java
@@ -6,15 +6,19 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.support.EncodedResource;
 import org.springframework.core.io.support.PropertySourceFactory;
 
+import java.io.IOException;
+import java.util.Objects;
 import java.util.Properties;
 
 public class YamlPropertySourceFactory implements PropertySourceFactory {
 
     @Override
-    public PropertySource<?> createPropertySource(String name, EncodedResource resource) {
+    public PropertySource<?> createPropertySource(String name, EncodedResource resource) throws IOException {
         YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
         factory.setResources(resource.getResource());
+
         Properties properties = factory.getObject();
+
         return new PropertiesPropertySource(
                 name != null ? name : resource.getResource().getFilename(),
                 properties != null ? properties : new Properties()

--- a/src/main/java/org/example/fanzip/controller/HomeController.java
+++ b/src/main/java/org/example/fanzip/controller/HomeController.java
@@ -1,8 +1,10 @@
 package org.example.fanzip.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @Slf4j
@@ -11,5 +13,12 @@ public class HomeController {
     public String home() {
         log.info("================> HomeController /");
         return "login";
+    }
+    
+    @GetMapping("/health")
+    @ResponseBody
+    public ResponseEntity<String> health() {
+        log.info("================> Health check");
+        return ResponseEntity.ok("Application is running!");
     }
 }

--- a/src/main/java/org/example/fanzip/fancard/constants/FancardConstants.java
+++ b/src/main/java/org/example/fanzip/fancard/constants/FancardConstants.java
@@ -1,0 +1,62 @@
+package org.example.fanzip.fancard.constants;
+
+import org.example.fanzip.fancard.dto.response.BenefitDto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public final class FancardConstants {
+    
+    private FancardConstants() {}
+    
+    // 테스트용 고정값들 (실제 운영에서는 DB나 설정 파일에서 관리)
+    public static final class TestData {
+        public static final Long TEST_INFLUENCER_ID = 1L;
+        public static final String TEST_INFLUENCER_NAME = "테스트 인플루언서";
+        public static final String TEST_CATEGORY = "BEAUTY";
+        public static final String TEST_PROFILE_IMAGE = "https://example.com/profiles/test.jpg";
+        public static final Boolean TEST_IS_VERIFIED = true;
+        
+        public static final Long TEST_GRADE_ID = 4L;
+        public static final String TEST_GRADE_NAME = "VIP";
+        public static final String TEST_GRADE_COLOR = "#8B008B";
+        public static final String TEST_BENEFITS_DESCRIPTION = "VIP 등급 최고 혜택";
+        
+        public static final BigDecimal TEST_MONTHLY_AMOUNT = BigDecimal.valueOf(10000.00);
+        public static final BigDecimal TEST_TOTAL_PAID_AMOUNT = BigDecimal.valueOf(120000.00);
+        public static final String TEST_MEMBERSHIP_STATUS = "ACTIVE";
+        public static final Boolean TEST_AUTO_RENEWAL = true;
+        
+        public static final String TEST_RESERVATION_NUMBER = "FM20250722001";
+        public static final String TEST_MEETING_TITLE = "테스트 인플루언서 팬미팅 2025";
+        public static final String TEST_VENUE_NAME = "올림픽공원 K-아트홀";
+        public static final String TEST_SEAT_NUMBER = "A-15";
+        
+        public static final List<BenefitDto> TEST_BENEFITS = List.of(
+            BenefitDto.builder()
+                .benefitId(1L)
+                .benefitType("DISCOUNT")
+                .benefitName("상품 할인")
+                .benefitValue("20%")
+                .description("모든 굿즈 20% 할인")
+                .isActive(true)
+                .build(),
+            BenefitDto.builder()
+                .benefitId(2L)
+                .benefitType("PRIORITY")
+                .benefitName("우선 예매")
+                .benefitValue("VIP_PRIORITY")
+                .description("팬미팅 VIP 등급 우선 예매")
+                .isActive(true)
+                .build()
+        );
+    }
+    
+    public static final class QrCode {
+        public static final String URL_PREFIX = "https://api.fanzip.com/qr/entry?code=";
+        public static final String CODE_PREFIX = "ENTRY_USER";
+        public static final String CODE_SEPARATOR = "_";
+        public static final String STATUS_ACTIVE = "ACTIVE";
+        public static final int EXPIRY_HOURS = 1;
+    }
+}

--- a/src/main/java/org/example/fanzip/fancard/controller/FancardController.java
+++ b/src/main/java/org/example/fanzip/fancard/controller/FancardController.java
@@ -1,0 +1,56 @@
+package org.example.fanzip.fancard.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.example.fanzip.fancard.dto.request.QrCodeRequest;
+import org.example.fanzip.fancard.dto.response.*;
+import org.example.fanzip.fancard.service.FancardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Api(tags = "Fancard API", description = "팬카드 관리 API")
+@RestController
+@RequestMapping("/api/fancards")
+public class FancardController {
+    
+    private final FancardService fancardService;
+    
+    @Autowired
+    public FancardController(FancardService fancardService) {
+        this.fancardService = fancardService;
+    }
+    
+    @ApiOperation(value = "사용자 팬카드 목록 조회", notes = "로그인한 사용자의 팬카드 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<FancardListWrapper> getUserFancards(HttpServletRequest request) {
+        Long userId = extractUserIdFromJWT(request);
+        FancardListWrapper fancards = fancardService.getUserFancards(userId);
+        return ResponseEntity.ok(fancards);
+    }
+
+    @ApiOperation(value = "팬카드 상세 조회", notes = "특정 팬카드의 상세 정보를 조회합니다.")
+    @GetMapping("/{cardId}")
+    public ResponseEntity<FancardDetailResponse> getFancardDetail(
+            @ApiParam(value = "팬카드 ID", required = true) @PathVariable Long cardId) {
+        FancardDetailResponse fancard = fancardService.getFancardDetail(cardId);
+        return ResponseEntity.ok(fancard);
+    }
+    
+    @ApiOperation(value = "입장 QR 코드 생성", notes = "팬미팅 입장용 QR 코드를 생성합니다.")
+    @PostMapping("/qr")
+    public ResponseEntity<QrCodeResponse> generateQrCode(
+            @ApiParam(value = "예약 정보", required = true) @RequestBody QrCodeRequest request) {
+        QrCodeResponse qrCode = fancardService.generateQrCode(request.getReservationId());
+        return ResponseEntity.ok(qrCode);
+    }
+    
+    private Long extractUserIdFromJWT(HttpServletRequest request) {
+        // TODO: JWT 토큰에서 실제 사용자 ID 추출 로직 구현
+        // 현재는 테스트용 고정값 반환
+        return 1L;
+    }
+}

--- a/src/main/java/org/example/fanzip/fancard/domain/Fancard.java
+++ b/src/main/java/org/example/fanzip/fancard/domain/Fancard.java
@@ -1,0 +1,55 @@
+package org.example.fanzip.fancard.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class Fancard {
+    
+    private Long cardId;
+    private Long membershipId;
+    private String cardNumber;
+    private String qrCode;
+    private LocalDate issueDate;
+    private LocalDate expiryDate;
+    private String cardDesignUrl;
+    private Boolean isActive;
+    private Long registeredDeviceId;
+    private LocalDateTime createdAt;
+    
+    protected Fancard() {}
+    
+    public Fancard(Long membershipId, String cardNumber, String qrCode, 
+                   LocalDate issueDate, LocalDate expiryDate, String cardDesignUrl) {
+        this.membershipId = membershipId;
+        this.cardNumber = cardNumber;
+        this.qrCode = qrCode;
+        this.issueDate = issueDate;
+        this.expiryDate = expiryDate;
+        this.cardDesignUrl = cardDesignUrl;
+        this.isActive = true;
+        this.createdAt = LocalDateTime.now();
+    }
+    
+    public Long getCardId() { return cardId; }
+    public Long getMembershipId() { return membershipId; }
+    public String getCardNumber() { return cardNumber; }
+    public String getQrCode() { return qrCode; }
+    public LocalDate getIssueDate() { return issueDate; }
+    public LocalDate getExpiryDate() { return expiryDate; }
+    public String getCardDesignUrl() { return cardDesignUrl; }
+    public Boolean getIsActive() { return isActive; }
+    public Long getRegisteredDeviceId() { return registeredDeviceId; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    
+    public void setRegisteredDeviceId(Long registeredDeviceId) {
+        this.registeredDeviceId = registeredDeviceId;
+    }
+    
+    public void deactivate() {
+        this.isActive = false;
+    }
+    
+    public void activate() {
+        this.isActive = true;
+    }
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/request/QrCodeRequest.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/request/QrCodeRequest.java
@@ -1,0 +1,12 @@
+package org.example.fanzip.fancard.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrCodeRequest {
+    private Long reservationId;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BenefitDto {
     private Long benefitId;
     private String benefitType;

--- a/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
@@ -1,20 +1,13 @@
 package org.example.fanzip.fancard.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BenefitDto {
-    private Long benefitId;
-    private String benefitType;
-    private String benefitName;
-    private String benefitValue;
-    private String description;
-    private Boolean isActive;
-}
+public record BenefitDto(
+    Long benefitId,
+    String benefitType,
+    String benefitName,
+    String benefitValue,
+    String description,
+    Boolean isActive
+) {}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/BenefitDto.java
@@ -1,0 +1,19 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BenefitDto {
+    private Long benefitId;
+    private String benefitType;
+    private String benefitName;
+    private String benefitValue;
+    private String description;
+    private Boolean isActive;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
@@ -1,0 +1,21 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FancardDetailResponse {
+    private Long cardId;
+    private String cardNumber;
+    private String cardDesignUrl;
+    private InfluencerDto influencer;
+    private MembershipDto membership;
+    private List<BenefitDto> benefits;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FancardDetailResponse {
     private Long cardId;
     private String cardNumber;

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardListResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardListResponse.java
@@ -1,0 +1,30 @@
+package org.example.fanzip.fancard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FancardListResponse {
+    private Long cardId;
+    private String cardNumber;
+    private Long influencerId;
+    private String influencerName;
+    private String category;
+    private MembershipGradeDto membershipGrade;
+    private String cardDesignUrl;
+    private Boolean isActive;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate issueDate;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate expiryDate;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardListResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardListResponse.java
@@ -1,6 +1,7 @@
 package org.example.fanzip.fancard.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FancardListResponse {
     private Long cardId;
     private String cardNumber;

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardListWrapper.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardListWrapper.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FancardListWrapper {
     private List<FancardListResponse> fancards;
 }

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardListWrapper.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardListWrapper.java
@@ -1,0 +1,16 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FancardListWrapper {
+    private List<FancardListResponse> fancards;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardResponse.java
@@ -1,0 +1,58 @@
+package org.example.fanzip.fancard.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class FancardResponse {
+    private Long cardId;
+    private Long membershipId;
+    private String cardNumber;
+    private String qrCode;
+    private LocalDate issueDate;
+    private LocalDate expiryDate;
+    private String cardDesignUrl;
+    private Boolean isActive;
+    private String influencerName;
+    private String gradeName;
+    private String gradeColor;
+    private LocalDateTime createdAt;
+    
+    public FancardResponse() {}
+    
+    public FancardResponse(Long cardId, Long membershipId, String cardNumber, String qrCode,
+                          LocalDate issueDate, LocalDate expiryDate, String cardDesignUrl,
+                          Boolean isActive, String influencerName, String gradeName, 
+                          String gradeColor, LocalDateTime createdAt) {
+        this.cardId = cardId;
+        this.membershipId = membershipId;
+        this.cardNumber = cardNumber;
+        this.qrCode = qrCode;
+        this.issueDate = issueDate;
+        this.expiryDate = expiryDate;
+        this.cardDesignUrl = cardDesignUrl;
+        this.isActive = isActive;
+        this.influencerName = influencerName;
+        this.gradeName = gradeName;
+        this.gradeColor = gradeColor;
+        this.createdAt = createdAt;
+    }
+    
+    public Long getCardId() { return cardId; }
+    public Long getMembershipId() { return membershipId; }
+    public String getCardNumber() { return cardNumber; }
+    public String getQrCode() { return qrCode; }
+    public LocalDate getIssueDate() { return issueDate; }
+    public LocalDate getExpiryDate() { return expiryDate; }
+    public String getCardDesignUrl() { return cardDesignUrl; }
+    public Boolean getIsActive() { return isActive; }
+    public String getInfluencerName() { return influencerName; }
+    public String getGradeName() { return gradeName; }
+    public String getGradeColor() { return gradeColor; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    
+    public void setCardDesignUrl(String cardDesignUrl) { this.cardDesignUrl = cardDesignUrl; }
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
+    public void setInfluencerName(String influencerName) { this.influencerName = influencerName; }
+    public void setGradeName(String gradeName) { this.gradeName = gradeName; }
+    public void setGradeColor(String gradeColor) { this.gradeColor = gradeColor; }
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardResponse.java
@@ -1,58 +1,30 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor; 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Value
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 public class FancardResponse {
-    private Long cardId;
-    private Long membershipId;
-    private String cardNumber;
-    private String qrCode;
-    private LocalDate issueDate;
-    private LocalDate expiryDate;
-    private String cardDesignUrl;
-    private Boolean isActive;
-    private String influencerName;
-    private String gradeName;
-    private String gradeColor;
-    private LocalDateTime createdAt;
-    
-    public FancardResponse() {}
-    
-    public FancardResponse(Long cardId, Long membershipId, String cardNumber, String qrCode,
-                          LocalDate issueDate, LocalDate expiryDate, String cardDesignUrl,
-                          Boolean isActive, String influencerName, String gradeName, 
-                          String gradeColor, LocalDateTime createdAt) {
-        this.cardId = cardId;
-        this.membershipId = membershipId;
-        this.cardNumber = cardNumber;
-        this.qrCode = qrCode;
-        this.issueDate = issueDate;
-        this.expiryDate = expiryDate;
-        this.cardDesignUrl = cardDesignUrl;
-        this.isActive = isActive;
-        this.influencerName = influencerName;
-        this.gradeName = gradeName;
-        this.gradeColor = gradeColor;
-        this.createdAt = createdAt;
-    }
-    
-    public Long getCardId() { return cardId; }
-    public Long getMembershipId() { return membershipId; }
-    public String getCardNumber() { return cardNumber; }
-    public String getQrCode() { return qrCode; }
-    public LocalDate getIssueDate() { return issueDate; }
-    public LocalDate getExpiryDate() { return expiryDate; }
-    public String getCardDesignUrl() { return cardDesignUrl; }
-    public Boolean getIsActive() { return isActive; }
-    public String getInfluencerName() { return influencerName; }
-    public String getGradeName() { return gradeName; }
-    public String getGradeColor() { return gradeColor; }
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    
-    public void setCardDesignUrl(String cardDesignUrl) { this.cardDesignUrl = cardDesignUrl; }
-    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
-    public void setInfluencerName(String influencerName) { this.influencerName = influencerName; }
-    public void setGradeName(String gradeName) { this.gradeName = gradeName; }
-    public void setGradeColor(String gradeColor) { this.gradeColor = gradeColor; }
+    Long cardId;
+    Long membershipId;
+    String cardNumber;
+    String qrCode;
+    LocalDate issueDate;
+    LocalDate expiryDate;
+    String cardDesignUrl;
+    Boolean isActive;
+    String influencerName;
+    String gradeName;
+    String gradeColor;
+    LocalDateTime createdAt;
 }

--- a/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
@@ -1,0 +1,17 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InfluencerDto {
+    private Long influencerId;
+    private String category;
+    private String profileImage;
+    private Boolean isVerified;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InfluencerDto {
     private Long influencerId;
     private String category;

--- a/src/main/java/org/example/fanzip/fancard/dto/response/MembershipDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/MembershipDto.java
@@ -1,0 +1,27 @@
+package org.example.fanzip.fancard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MembershipDto {
+    private Long membershipId;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate subscriptionStart;
+    
+    private BigDecimal monthlyAmount;
+    private BigDecimal totalPaidAmount;
+    private String status;
+    private Boolean autoRenewal;
+    private MembershipGradeDto grade;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/MembershipDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/MembershipDto.java
@@ -1,6 +1,7 @@
 package org.example.fanzip.fancard.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MembershipDto {
     private Long membershipId;
     

--- a/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
@@ -1,0 +1,17 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MembershipGradeDto {
+    private Long gradeId;
+    private String gradeName;
+    private String color;
+    private String benefitsDescription;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
@@ -1,5 +1,6 @@
 package org.example.fanzip.fancard.dto.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MembershipGradeDto {
     private Long gradeId;
     private String gradeName;

--- a/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/MembershipGradeDto.java
@@ -1,18 +1,11 @@
 package org.example.fanzip.fancard.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MembershipGradeDto {
-    private Long gradeId;
-    private String gradeName;
-    private String color;
-    private String benefitsDescription;
-}
+public record MembershipGradeDto(
+    Long gradeId,
+    String gradeName,
+    String color,
+    String benefitsDescription
+) {}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/QrCodeResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/QrCodeResponse.java
@@ -1,0 +1,27 @@
+package org.example.fanzip.fancard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QrCodeResponse {
+    private String qrCode;
+    private String qrCodeUrl;
+    private String status;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime generatedAt;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expiresAt;
+    
+    private ReservationDto reservation;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/ReservationDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/ReservationDto.java
@@ -1,0 +1,25 @@
+package org.example.fanzip.fancard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReservationDto {
+    private Long reservationId;
+    private String reservationNumber;
+    private String meetingTitle;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime meetingDate;
+    
+    private String venueName;
+    private String seatNumber;
+}

--- a/src/main/java/org/example/fanzip/fancard/dto/response/ReservationDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/ReservationDto.java
@@ -1,6 +1,7 @@
 package org.example.fanzip.fancard.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationDto {
     private Long reservationId;
     private String reservationNumber;

--- a/src/main/java/org/example/fanzip/fancard/exception/FancardNotFoundException.java
+++ b/src/main/java/org/example/fanzip/fancard/exception/FancardNotFoundException.java
@@ -1,0 +1,12 @@
+package org.example.fanzip.fancard.exception;
+
+public class FancardNotFoundException extends RuntimeException {
+    
+    public FancardNotFoundException(String message) {
+        super(message);
+    }
+    
+    public FancardNotFoundException(Long cardId) {
+        super("팬카드를 찾을 수 없습니다. (ID: " + cardId + ")");
+    }
+}

--- a/src/main/java/org/example/fanzip/fancard/mapper/FancardMapper.java
+++ b/src/main/java/org/example/fanzip/fancard/mapper/FancardMapper.java
@@ -1,0 +1,28 @@
+package org.example.fanzip.fancard.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.fanzip.fancard.domain.Fancard;
+
+import java.util.List;
+
+@Mapper
+public interface FancardMapper {
+    List<Fancard> findByMembershipId(@Param("membershipId") Long membershipId);
+    
+    Fancard findByCardNumber(@Param("cardNumber") String cardNumber);
+    
+    Fancard findByQrCode(@Param("qrCode") String qrCode);
+    
+    List<Fancard> findActiveCardsByMembershipIds(@Param("membershipIds") List<Long> membershipIds);
+    
+    Fancard findActiveCardByMembershipId(@Param("membershipId") Long membershipId);
+    
+    Fancard findById(@Param("cardId") Long cardId);
+    
+    void insert(Fancard fancard);
+    
+    void update(Fancard fancard);
+    
+    void delete(@Param("cardId") Long cardId);
+}

--- a/src/main/java/org/example/fanzip/fancard/service/FancardService.java
+++ b/src/main/java/org/example/fanzip/fancard/service/FancardService.java
@@ -1,0 +1,14 @@
+package org.example.fanzip.fancard.service;
+
+import org.example.fanzip.fancard.dto.response.FancardDetailResponse;
+import org.example.fanzip.fancard.dto.response.FancardListWrapper;
+import org.example.fanzip.fancard.dto.response.QrCodeResponse;
+
+public interface FancardService {
+    
+    FancardListWrapper getUserFancards(Long userId);
+    
+    FancardDetailResponse getFancardDetail(Long cardId);
+    
+    QrCodeResponse generateQrCode(Long reservationId);
+}

--- a/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
+++ b/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
@@ -20,7 +20,6 @@ public class FancardServiceImpl implements FancardService {
 
     private final FancardMapper fancardMapper;
 
-    @Autowired
     public FancardServiceImpl(FancardMapper fancardMapper) {
         this.fancardMapper = fancardMapper;
     }
@@ -150,12 +149,11 @@ public class FancardServiceImpl implements FancardService {
     }
 
     private List<Long> getMembershipIdsByUserId(Long userId) {
-        // TODO: Membership 서비스나 매퍼를 통해 실제 메버십 ID 목록 조회
-        // 현재는 테스트 데이터 반환
+        // TODO: MembershipService 의존성 주입 후 실제 조회로 변경 필요
         if (userId.equals(1L)) {
             return List.of(1L);
         }
-        return List.of();
+        return Collections.emptyList();
     }
 
     private String getInfluencerNameByMembershipId(Long membershipId) {

--- a/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
+++ b/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
@@ -1,0 +1,175 @@
+package org.example.fanzip.fancard.service;
+
+import org.example.fanzip.fancard.dto.response.*;
+import org.example.fanzip.fancard.domain.Fancard;
+import org.example.fanzip.fancard.exception.FancardNotFoundException;
+import org.example.fanzip.fancard.mapper.FancardMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Collections;
+
+@Service
+@Transactional(readOnly = true)
+public class FancardServiceImpl implements FancardService {
+
+    private final FancardMapper fancardMapper;
+
+    @Autowired
+    public FancardServiceImpl(FancardMapper fancardMapper) {
+        this.fancardMapper = fancardMapper;
+    }
+
+    @Override
+    public FancardListWrapper getUserFancards(Long userId) {
+        List<Long> membershipIds = getMembershipIdsByUserId(userId);
+        List<Fancard> fancards = fancardMapper.findActiveCardsByMembershipIds(membershipIds);
+
+        List<FancardListResponse> fancardList = fancards.stream()
+                .map(this::convertToListResponse)
+                .collect(Collectors.toList());
+        
+        return FancardListWrapper.builder()
+                .fancards(fancardList)
+                .build();
+    }
+
+    @Override
+    public FancardDetailResponse getFancardDetail(Long cardId) {
+        Fancard fancard = fancardMapper.findById(cardId);
+        if (fancard == null) {
+            throw new FancardNotFoundException(cardId);
+        }
+
+        return convertToDetailResponse(fancard);
+    }
+
+    @Override
+    public QrCodeResponse generateQrCode(Long reservationId) {
+        // TODO: 실제 예약 정보 조회 로직 구현
+        String qrCode = "ENTRY_USER1_RES" + reservationId + "_" + LocalDateTime.now().toString().replace(":", "").replace(".", "");
+        String qrCodeUrl = "https://api.fanzip.com/qr/entry?code=" + qrCode;
+        
+        ReservationDto reservation = ReservationDto.builder()
+                .reservationId(reservationId)
+                .reservationNumber("FM20250722001")
+                .meetingTitle("테스트 인플루언서 팬미팅 2025")
+                .meetingDate(LocalDateTime.now().plusDays(30))
+                .venueName("올림픽공원 K-아트홀")
+                .seatNumber("A-15")
+                .build();
+        
+        return QrCodeResponse.builder()
+                .qrCode(qrCode)
+                .qrCodeUrl(qrCodeUrl)
+                .status("ACTIVE")
+                .generatedAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusHours(1))
+                .reservation(reservation)
+                .build();
+    }
+
+    private FancardListResponse convertToListResponse(Fancard fancard) {
+        MembershipGradeDto membershipGrade = MembershipGradeDto.builder()
+                .gradeId(4L)
+                .gradeName("VIP")
+                .color("#8B008B")
+                .build();
+
+        return FancardListResponse.builder()
+                .cardId(fancard.getCardId())
+                .cardNumber(fancard.getCardNumber())
+                .influencerId(1L)
+                .influencerName("테스트 인플루언서")
+                .category("BEAUTY")
+                .membershipGrade(membershipGrade)
+                .cardDesignUrl(fancard.getCardDesignUrl())
+                .isActive(fancard.getIsActive())
+                .issueDate(fancard.getIssueDate())
+                .expiryDate(fancard.getExpiryDate())
+                .build();
+    }
+    
+    private FancardDetailResponse convertToDetailResponse(Fancard fancard) {
+        InfluencerDto influencer = InfluencerDto.builder()
+                .influencerId(1L)
+                .category("BEAUTY")
+                .profileImage("https://example.com/profiles/test.jpg")
+                .isVerified(true)
+                .build();
+        
+        MembershipGradeDto grade = MembershipGradeDto.builder()
+                .gradeId(4L)
+                .gradeName("VIP")
+                .color("#8B008B")
+                .benefitsDescription("VIP 등급 최고 혜택")
+                .build();
+        
+        MembershipDto membership = MembershipDto.builder()
+                .membershipId(fancard.getMembershipId())
+                .subscriptionStart(fancard.getIssueDate())
+                .monthlyAmount(BigDecimal.valueOf(10000.00))
+                .totalPaidAmount(BigDecimal.valueOf(120000.00))
+                .status("ACTIVE")
+                .autoRenewal(true)
+                .grade(grade)
+                .build();
+        
+        List<BenefitDto> benefits = List.of(
+                BenefitDto.builder()
+                        .benefitId(1L)
+                        .benefitType("DISCOUNT")
+                        .benefitName("상품 할인")
+                        .benefitValue("20%")
+                        .description("모든 굿즈 20% 할인")
+                        .isActive(true)
+                        .build(),
+                BenefitDto.builder()
+                        .benefitId(2L)
+                        .benefitType("PRIORITY")
+                        .benefitName("우선 예매")
+                        .benefitValue("VIP_PRIORITY")
+                        .description("팬미팅 VIP 등급 우선 예매")
+                        .isActive(true)
+                        .build()
+        );
+        
+        return FancardDetailResponse.builder()
+                .cardId(fancard.getCardId())
+                .cardNumber(fancard.getCardNumber())
+                .cardDesignUrl(fancard.getCardDesignUrl())
+                .influencer(influencer)
+                .membership(membership)
+                .benefits(benefits)
+                .build();
+    }
+
+    private List<Long> getMembershipIdsByUserId(Long userId) {
+        // TODO: Membership 서비스나 매퍼를 통해 실제 메버십 ID 목록 조회
+        // 현재는 테스트 데이터 반환
+        if (userId.equals(1L)) {
+            return List.of(1L);
+        }
+        return List.of();
+    }
+
+    private String getInfluencerNameByMembershipId(Long membershipId) {
+        // TODO: Membership 서비스를 통해 실제 인플루언서 이름 조회
+        return "테스트 인플루언서";
+    }
+
+    private String getGradeNameByMembershipId(Long membershipId) {
+        // TODO: Membership 서비스를 통해 실제 등급 이름 조회
+        return "VIP";
+    }
+
+    private String getGradeColorByMembershipId(Long membershipId) {
+        // TODO: Membership 서비스를 통해 실제 등급 색상 조회
+        return "#8B008B";
+    }
+}

--- a/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
+++ b/src/main/java/org/example/fanzip/fancard/service/FancardServiceImpl.java
@@ -4,6 +4,7 @@ import org.example.fanzip.fancard.dto.response.*;
 import org.example.fanzip.fancard.domain.Fancard;
 import org.example.fanzip.fancard.exception.FancardNotFoundException;
 import org.example.fanzip.fancard.mapper.FancardMapper;
+import org.example.fanzip.fancard.constants.FancardConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,41 +52,43 @@ public class FancardServiceImpl implements FancardService {
     @Override
     public QrCodeResponse generateQrCode(Long reservationId) {
         // TODO: 실제 예약 정보 조회 로직 구현
-        String qrCode = "ENTRY_USER1_RES" + reservationId + "_" + LocalDateTime.now().toString().replace(":", "").replace(".", "");
-        String qrCodeUrl = "https://api.fanzip.com/qr/entry?code=" + qrCode;
+        String timestamp = LocalDateTime.now().toString().replace(":", "").replace(".", "");
+        String qrCode = FancardConstants.QrCode.CODE_PREFIX + "1_RES" + reservationId + 
+                       FancardConstants.QrCode.CODE_SEPARATOR + timestamp;
+        String qrCodeUrl = FancardConstants.QrCode.URL_PREFIX + qrCode;
         
         ReservationDto reservation = ReservationDto.builder()
                 .reservationId(reservationId)
-                .reservationNumber("FM20250722001")
-                .meetingTitle("테스트 인플루언서 팬미팅 2025")
+                .reservationNumber(FancardConstants.TestData.TEST_RESERVATION_NUMBER)
+                .meetingTitle(FancardConstants.TestData.TEST_MEETING_TITLE)
                 .meetingDate(LocalDateTime.now().plusDays(30))
-                .venueName("올림픽공원 K-아트홀")
-                .seatNumber("A-15")
+                .venueName(FancardConstants.TestData.TEST_VENUE_NAME)
+                .seatNumber(FancardConstants.TestData.TEST_SEAT_NUMBER)
                 .build();
         
         return QrCodeResponse.builder()
                 .qrCode(qrCode)
                 .qrCodeUrl(qrCodeUrl)
-                .status("ACTIVE")
+                .status(FancardConstants.QrCode.STATUS_ACTIVE)
                 .generatedAt(LocalDateTime.now())
-                .expiresAt(LocalDateTime.now().plusHours(1))
+                .expiresAt(LocalDateTime.now().plusHours(FancardConstants.QrCode.EXPIRY_HOURS))
                 .reservation(reservation)
                 .build();
     }
 
     private FancardListResponse convertToListResponse(Fancard fancard) {
         MembershipGradeDto membershipGrade = MembershipGradeDto.builder()
-                .gradeId(4L)
-                .gradeName("VIP")
-                .color("#8B008B")
+                .gradeId(FancardConstants.TestData.TEST_GRADE_ID)
+                .gradeName(FancardConstants.TestData.TEST_GRADE_NAME)
+                .color(FancardConstants.TestData.TEST_GRADE_COLOR)
                 .build();
 
         return FancardListResponse.builder()
                 .cardId(fancard.getCardId())
                 .cardNumber(fancard.getCardNumber())
-                .influencerId(1L)
-                .influencerName("테스트 인플루언서")
-                .category("BEAUTY")
+                .influencerId(FancardConstants.TestData.TEST_INFLUENCER_ID)
+                .influencerName(FancardConstants.TestData.TEST_INFLUENCER_NAME)
+                .category(FancardConstants.TestData.TEST_CATEGORY)
                 .membershipGrade(membershipGrade)
                 .cardDesignUrl(fancard.getCardDesignUrl())
                 .isActive(fancard.getIsActive())
@@ -96,47 +99,28 @@ public class FancardServiceImpl implements FancardService {
     
     private FancardDetailResponse convertToDetailResponse(Fancard fancard) {
         InfluencerDto influencer = InfluencerDto.builder()
-                .influencerId(1L)
-                .category("BEAUTY")
-                .profileImage("https://example.com/profiles/test.jpg")
-                .isVerified(true)
+                .influencerId(FancardConstants.TestData.TEST_INFLUENCER_ID)
+                .category(FancardConstants.TestData.TEST_CATEGORY)
+                .profileImage(FancardConstants.TestData.TEST_PROFILE_IMAGE)
+                .isVerified(FancardConstants.TestData.TEST_IS_VERIFIED)
                 .build();
         
         MembershipGradeDto grade = MembershipGradeDto.builder()
-                .gradeId(4L)
-                .gradeName("VIP")
-                .color("#8B008B")
-                .benefitsDescription("VIP 등급 최고 혜택")
+                .gradeId(FancardConstants.TestData.TEST_GRADE_ID)
+                .gradeName(FancardConstants.TestData.TEST_GRADE_NAME)
+                .color(FancardConstants.TestData.TEST_GRADE_COLOR)
+                .benefitsDescription(FancardConstants.TestData.TEST_BENEFITS_DESCRIPTION)
                 .build();
         
         MembershipDto membership = MembershipDto.builder()
                 .membershipId(fancard.getMembershipId())
                 .subscriptionStart(fancard.getIssueDate())
-                .monthlyAmount(BigDecimal.valueOf(10000.00))
-                .totalPaidAmount(BigDecimal.valueOf(120000.00))
-                .status("ACTIVE")
-                .autoRenewal(true)
+                .monthlyAmount(FancardConstants.TestData.TEST_MONTHLY_AMOUNT)
+                .totalPaidAmount(FancardConstants.TestData.TEST_TOTAL_PAID_AMOUNT)
+                .status(FancardConstants.TestData.TEST_MEMBERSHIP_STATUS)
+                .autoRenewal(FancardConstants.TestData.TEST_AUTO_RENEWAL)
                 .grade(grade)
                 .build();
-        
-        List<BenefitDto> benefits = List.of(
-                BenefitDto.builder()
-                        .benefitId(1L)
-                        .benefitType("DISCOUNT")
-                        .benefitName("상품 할인")
-                        .benefitValue("20%")
-                        .description("모든 굿즈 20% 할인")
-                        .isActive(true)
-                        .build(),
-                BenefitDto.builder()
-                        .benefitId(2L)
-                        .benefitType("PRIORITY")
-                        .benefitName("우선 예매")
-                        .benefitValue("VIP_PRIORITY")
-                        .description("팬미팅 VIP 등급 우선 예매")
-                        .isActive(true)
-                        .build()
-        );
         
         return FancardDetailResponse.builder()
                 .cardId(fancard.getCardId())
@@ -144,7 +128,7 @@ public class FancardServiceImpl implements FancardService {
                 .cardDesignUrl(fancard.getCardDesignUrl())
                 .influencer(influencer)
                 .membership(membership)
-                .benefits(benefits)
+                .benefits(FancardConstants.TestData.TEST_BENEFITS)
                 .build();
     }
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,10 @@
+jdbc:
+  driver: org.h2.Driver
+  url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+  username: sa
+  password: 
+
+logging:
+  level:
+    org.springframework.jdbc: DEBUG
+    org.mybatis: DEBUG

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -1,0 +1,132 @@
+-- H2 데이터베이스용 테스트 테이블 및 데이터
+
+-- 사용자 테이블
+CREATE TABLE IF NOT EXISTS users (
+    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    nickname VARCHAR(100),
+    phone VARCHAR(20),
+    social_type VARCHAR(20),
+    social_id VARCHAR(255),
+    address1 VARCHAR(255),
+    address2 VARCHAR(255),
+    zipcode VARCHAR(10),
+    recipient_name VARCHAR(100),
+    recipient_phone VARCHAR(20),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL
+);
+
+-- 인플루언서 테이블
+CREATE TABLE IF NOT EXISTS influencers (
+    influencer_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    influencer_name VARCHAR(100) NOT NULL,
+    category VARCHAR(20),
+    description TEXT,
+    profile_image VARCHAR(500),
+    cover_image VARCHAR(500),
+    is_verified BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id)
+);
+
+-- 멤버십 등급 테이블
+CREATE TABLE IF NOT EXISTS membership_grades (
+    grade_id INT AUTO_INCREMENT PRIMARY KEY,
+    grade_name VARCHAR(50) NOT NULL,
+    color VARCHAR(7) NOT NULL,
+    benefits_description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 멤버십 테이블
+CREATE TABLE IF NOT EXISTS memberships (
+    membership_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    influencer_id BIGINT NOT NULL,
+    grade_id INT NOT NULL,
+    subscription_start DATE NOT NULL,
+    subscription_end DATE NOT NULL,
+    monthly_amount DECIMAL(10, 2) NOT NULL,
+    total_paid_amount DECIMAL(12, 2) DEFAULT 0,
+    status VARCHAR(20) DEFAULT 'ACTIVE',
+    auto_renewal BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    FOREIGN KEY (influencer_id) REFERENCES influencers(influencer_id),
+    FOREIGN KEY (grade_id) REFERENCES membership_grades(grade_id)
+);
+
+-- 사용자 기기 테이블
+CREATE TABLE IF NOT EXISTS user_devices (
+    device_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    device_identifier VARCHAR(255) UNIQUE NOT NULL,
+    device_name VARCHAR(100),
+    device_type VARCHAR(20),
+    is_primary BOOLEAN DEFAULT FALSE,
+    is_active BOOLEAN DEFAULT TRUE,
+    registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id)
+);
+
+-- 팬카드 테이블
+CREATE TABLE IF NOT EXISTS fan_cards (
+    card_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    membership_id BIGINT NOT NULL,
+    card_number VARCHAR(50) UNIQUE NOT NULL,
+    qr_code VARCHAR(500) UNIQUE NOT NULL,
+    issue_date DATE NOT NULL,
+    expiry_date DATE NOT NULL,
+    card_design_url VARCHAR(500),
+    is_active BOOLEAN DEFAULT TRUE,
+    registered_device_id BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (membership_id) REFERENCES memberships(membership_id),
+    FOREIGN KEY (registered_device_id) REFERENCES user_devices(device_id)
+);
+
+-- 테스트 데이터 삽입
+
+-- 멤버십 등급 데이터
+INSERT INTO membership_grades (grade_name, color, benefits_description) VALUES
+('SILVER', '#C0C0C0', '기본 혜택 제공'),
+('GOLD', '#FFD700', '골드 등급 혜택'),
+('PLATINUM', '#E5E4E2', '플래티넘 등급 특별 혜택'),
+('VIP', '#8B008B', 'VIP 등급 최고 혜택');
+
+-- 테스트용 사용자 데이터
+INSERT INTO users (email, name, password, nickname, phone) 
+SELECT 'test@example.com', '테스트 사용자', 'password123', 'testuser', '010-1234-5678'
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = 'test@example.com');
+
+INSERT INTO users (email, name, password, nickname, phone) 
+SELECT 'influencer@example.com', '인플루언서', 'password123', 'influencer1', '010-9876-5432'
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = 'influencer@example.com');
+
+-- 테스트용 인플루언서 데이터
+INSERT INTO influencers (user_id, influencer_name, category, description, is_verified) 
+SELECT 2, '테스트 인플루언서', 'BEAUTY', '뷰티 인플루언서입니다.', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM influencers WHERE user_id = 2);
+
+-- 테스트용 멤버십 데이터
+INSERT INTO memberships (user_id, influencer_id, grade_id, subscription_start, subscription_end, monthly_amount) 
+SELECT 1, 1, 4, '2024-01-01', '2024-12-31', 10000.00
+WHERE NOT EXISTS (SELECT 1 FROM memberships WHERE user_id = 1 AND influencer_id = 1);
+
+-- 테스트용 사용자 기기 데이터
+INSERT INTO user_devices (user_id, device_identifier, device_name, device_type, is_primary) 
+SELECT 1, 'test-device-001', 'iPhone 15', 'MOBILE', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM user_devices WHERE device_identifier = 'test-device-001');
+
+-- 테스트용 팬카드 데이터
+INSERT INTO fan_cards (membership_id, card_number, qr_code, issue_date, expiry_date, card_design_url, registered_device_id) 
+SELECT 1, 'FC-2024-000001', 'https://qr.fanzip.com/FC-2024-000001', '2024-01-01', '2024-12-31', 'https://cdn.fanzip.com/cards/design1.jpg', 1
+WHERE NOT EXISTS (SELECT 1 FROM fan_cards WHERE card_number = 'FC-2024-000001');

--- a/src/main/resources/mappers/FancardMapper.xml
+++ b/src/main/resources/mappers/FancardMapper.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.fanzip.fancard.mapper.FancardMapper">
+
+    <!-- Fancard ResultMap -->
+    <resultMap id="fancardResultMap" type="org.example.fanzip.fancard.domain.Fancard">
+        <id property="cardId" column="card_id"/>
+        <result property="membershipId" column="membership_id"/>
+        <result property="cardNumber" column="card_number"/>
+        <result property="qrCode" column="qr_code"/>
+        <result property="issueDate" column="issue_date"/>
+        <result property="expiryDate" column="expiry_date"/>
+        <result property="cardDesignUrl" column="card_design_url"/>
+        <result property="isActive" column="is_active"/>
+        <result property="registeredDeviceId" column="registered_device_id"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <!-- 멤버십 ID로 팬카드 목록 조회 -->
+    <select id="findByMembershipId" parameterType="long" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        WHERE membership_id = #{membershipId}
+    </select>
+
+    <!-- 카드 번호로 팬카드 조회 -->
+    <select id="findByCardNumber" parameterType="string" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        WHERE card_number = #{cardNumber}
+    </select>
+
+    <!-- QR 코드로 팬카드 조회 -->
+    <select id="findByQrCode" parameterType="string" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        WHERE qr_code = #{qrCode}
+    </select>
+
+    <!-- 여러 멤버십 ID의 활성 팬카드 목록 조회 -->
+    <select id="findActiveCardsByMembershipIds" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        <where>
+            <if test="membershipIds != null and membershipIds.size() > 0">
+                membership_id IN
+                <foreach item="membershipId" collection="membershipIds" open="(" separator="," close=")">
+                    #{membershipId}
+                </foreach>
+                AND is_active = true
+            </if>
+            <if test="membershipIds == null or membershipIds.size() == 0">
+                1 = 0
+            </if>
+        </where>
+    </select>
+
+    <!-- 멤버십 ID의 활성 팬카드 조회 -->
+    <select id="findActiveCardByMembershipId" parameterType="long" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        WHERE membership_id = #{membershipId}
+        AND is_active = true
+        LIMIT 1
+    </select>
+
+    <!-- ID로 팬카드 조회 -->
+    <select id="findById" parameterType="long" resultMap="fancardResultMap">
+        SELECT card_id, membership_id, card_number, qr_code, issue_date, expiry_date, 
+               card_design_url, is_active, registered_device_id, created_at
+        FROM fan_cards
+        WHERE card_id = #{cardId}
+    </select>
+
+    <!-- 팬카드 등록 -->
+    <insert id="insert" parameterType="org.example.fanzip.fancard.domain.Fancard" useGeneratedKeys="true" keyProperty="cardId">
+        INSERT INTO fan_cards (membership_id, card_number, qr_code, issue_date, expiry_date, 
+                              card_design_url, is_active, registered_device_id)
+        VALUES (#{membershipId}, #{cardNumber}, #{qrCode}, #{issueDate}, #{expiryDate}, 
+                #{cardDesignUrl}, #{isActive}, #{registeredDeviceId})
+    </insert>
+
+    <!-- 팬카드 수정 -->
+    <update id="update" parameterType="org.example.fanzip.fancard.domain.Fancard">
+        UPDATE fan_cards
+        SET membership_id = #{membershipId},
+            card_number = #{cardNumber},
+            qr_code = #{qrCode},
+            issue_date = #{issueDate},
+            expiry_date = #{expiryDate},
+            card_design_url = #{cardDesignUrl},
+            is_active = #{isActive},
+            registered_device_id = #{registeredDeviceId}
+        WHERE card_id = #{cardId}
+    </update>
+
+    <!-- 팬카드 삭제 -->
+    <delete id="delete" parameterType="long">
+        DELETE FROM fan_cards
+        WHERE card_id = #{cardId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -6,6 +6,7 @@
 <configuration>
     <settings>
         <setting name="mapUnderscoreToCamelCase" value="true"/>
+        <setting name="jdbcTypeForNull" value="NULL"/>
     </settings>
 
     <typeAliases>
@@ -17,5 +18,4 @@
         <mapper resource="org/example/fanzip/membership/mapper/MembershipMapper.xml"/>
         <mapper resource="org/example/fanzip/market/mapper/MarketMapper.xml"/>
     </mappers>
-
 </configuration>

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -1,9 +1,18 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <html>
 <head>
-    <title>Title</title>
+    <title>Fanzip API Server</title>
 </head>
 <body>
-<h1>Hello, Spring world!</h1>
+<h1>Fanzip API Server</h1>
+<h2>서버 상태</h2>
+<ul>
+    <li><a href="health">Health Check</a></li>
+</ul>
+<h2>API 문서</h2>
+<ul>
+    <li><a href="swagger-ui.html">Swagger UI</a></li>
+    <li><a href="api/fancards">Fancard API</a></li>
+</ul>
 </body>
 </html>

--- a/src/test/java/org/example/fanzip/payment/config/RootConfigTest.java
+++ b/src/test/java/org/example/fanzip/payment/config/RootConfigTest.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 @ContextConfiguration(classes = RootConfig.class)
 @Slf4j
 @PropertySource("classpath:application.yml")
+@PropertySource(value = "classpath:application-test.yml", factory = YamlPropertySourceFactory.class)
 class RootConfigTest {
     @Autowired
     private SqlSessionFactory sqlSessionFactory;


### PR DESCRIPTION
## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [x] Chore

<br/>

## 🔎 작업 내용

- 팬카드 API (`GET /api/fancards`, `GET /api/fancards/{id}`, `POST /api/fancards/qr`) 기본 흐름 구현
- 팬카드 도메인 설계 및 DTO 구조 정립
- 팬카드 Mapper 및 MyBatis XML 쿼리 작성
- 팬카드 상세 조회, 목록 조회, QR 생성 API 구현
- Swagger, ExceptionHandler, Jackson Config 등 공통 설정 반영

<br/>
- Closes #13

<br/>

## 📸 이미지 첨부


<br/>

## 📬 전달 사항
- JWT 사용자 식별 기능은 현재 mock로 구성되어 있으며, 추후 인증 모듈과 연동 예정
- QR 생성 로직은 임시 UUID 기반이며 추후에 디벨롭 예정

<br/>

## 🔧 앞으로의 과제
- 구독 페이지와 연계해 Mock 데이터 줄이고 완성도 높일 예정
- QR 유효시간 설정, 만료 처리 로직
- 사용자 인증 연동 및 사용자별 기기 등록 로직 연결