### PR TITLE
[feat] 인플루언서 전체 목록 조회 페이지

### DIFF
--- a/src/main/java/org/example/fanzip/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/config/RootConfig.java
@@ -28,7 +28,8 @@ import javax.sql.DataSource;
         "org.example.fanzip.payment.mapper",
         "org.example.fanzip.market.mapper",
         "org.example.fanzip.cart.mapper",
-        "org.example.fanzip.membership.mapper"
+        "org.example.fanzip.membership.mapper",
+        "org.example.fanzip.influencer.mapper"
 })
 @ComponentScan(basePackages = {
         "org.example.fanzip",
@@ -36,7 +37,8 @@ import javax.sql.DataSource;
         "org.example.fanzip.payment",
         "org.example.fanzip.market",
         "org.example.fanzip.cart",
-        "org.example.fanzip.membership.service"
+        "org.example.fanzip.membership.service",
+        "org.example.fanzip.influencer.service"
 })
 public class RootConfig {
     @Value("${spring.datasource.driver-class-name}") String driver;
@@ -69,6 +71,7 @@ public class RootConfig {
         sqlSessionFactory.setDataSource(dataSource());
         return (SqlSessionFactory) sqlSessionFactory.getObject();
     }
+
     @Bean
     public DataSourceTransactionManager transactionManager(){
         DataSourceTransactionManager manager = new DataSourceTransactionManager(dataSource());

--- a/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
+++ b/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
@@ -1,0 +1,45 @@
+package org.example.fanzip.influencer.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
+import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
+import org.example.fanzip.influencer.service.InfluencerService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/influencers")
+public class InfluencerController {
+
+    private final InfluencerService influencerService;
+
+    // 전체 인플루언서 목록 조회 (필터: 선택적 카테고리 지정 가능)
+    @GetMapping
+    public ResponseEntity<List<InfluencerResponseDTO>> getInfluencers(
+            // 카테고리 지정하면 /api/influencers/?category= 형태로 조회
+            @RequestParam(value = "category", required = false) InfluencerCategory category,
+            HttpServletRequest request) {
+
+        // JWT Interceptor에서 설정한 userId를 가져옴 (구독한 인플루언서 제외용)
+        Long userId = (Long) request.getAttribute("userId");
+        
+        InfluencerRequestDTO requestDTO = InfluencerRequestDTO.builder()
+                .userId(userId)
+                .category(category)
+                .build();
+        
+        List<InfluencerResponseDTO> influencerList = influencerService.findAll(requestDTO);
+
+        return ResponseEntity.ok(influencerList);
+
+    }
+}

--- a/src/main/java/org/example/fanzip/influencer/domain/InfluencerVO.java
+++ b/src/main/java/org/example/fanzip/influencer/domain/InfluencerVO.java
@@ -1,0 +1,20 @@
+package org.example.fanzip.influencer.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InfluencerVO {
+    private Long influencerId;        // PK
+    private String influencerName;    // 인플루언서 이름
+    private InfluencerCategory category; // 인플루언서 카테고리
+    private String profileImage;      // 프로필 이미지 URL
+}

--- a/src/main/java/org/example/fanzip/influencer/domain/enums/InfluencerCategory.java
+++ b/src/main/java/org/example/fanzip/influencer/domain/enums/InfluencerCategory.java
@@ -1,0 +1,19 @@
+package org.example.fanzip.influencer.domain.enums;
+
+public enum InfluencerCategory {
+    BEAUTY,        // 뷰티
+    GAME,          // 게임
+    DAILY,         // 일상
+    FASHION,       // 패션
+    COOKING,       // 요리
+    HEALTH,        // 다이어트/건강
+    PET,           // 반려동물
+    KIDS,          // 키즈
+    EDUCATION,     // 교육/지식
+    TRAVEL,        // 여행
+    MUSIC,         // 음악
+    FITNESS,       // 운동
+    SPORTS,        // 스포츠
+    LANGUAGE,      // 언어
+    ETC            // 기타
+}

--- a/src/main/java/org/example/fanzip/influencer/dto/InfluencerRequestDTO.java
+++ b/src/main/java/org/example/fanzip/influencer/dto/InfluencerRequestDTO.java
@@ -1,0 +1,16 @@
+package org.example.fanzip.influencer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class InfluencerRequestDTO {
+    private InfluencerCategory category;  // 필터링 조건(카테고리별 필터링)
+    private Long userId;                  // 현재 로그인한 사용자가 구독한 인플루언서 목록을 제외하기 위해 사용
+}

--- a/src/main/java/org/example/fanzip/influencer/dto/InfluencerResponseDTO.java
+++ b/src/main/java/org/example/fanzip/influencer/dto/InfluencerResponseDTO.java
@@ -1,0 +1,31 @@
+package org.example.fanzip.influencer.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.fanzip.influencer.domain.InfluencerVO;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class InfluencerResponseDTO {
+
+    private Long influencerId;
+    private String influencerName;
+    private String profileImage;
+    private InfluencerCategory category;
+
+    public static InfluencerResponseDTO from(InfluencerVO influencerVO){
+        return InfluencerResponseDTO.builder()
+                .influencerId(influencerVO.getInfluencerId())
+                .influencerName(influencerVO.getInfluencerName())
+                .profileImage(influencerVO.getProfileImage())
+                .category(influencerVO.getCategory())
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
+++ b/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
@@ -1,0 +1,15 @@
+package org.example.fanzip.influencer.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.fanzip.influencer.domain.InfluencerVO;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+
+import java.util.List;
+
+@Mapper
+public interface InfluencerMapper {
+
+    List<InfluencerVO> findAllFiltered(@Param("userId") Long userId,
+                                       @Param("category") InfluencerCategory category);
+}

--- a/src/main/java/org/example/fanzip/influencer/service/InfluencerService.java
+++ b/src/main/java/org/example/fanzip/influencer/service/InfluencerService.java
@@ -1,0 +1,13 @@
+package org.example.fanzip.influencer.service;
+
+
+import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
+import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
+
+import java.util.List;
+
+public interface InfluencerService {
+
+    List<InfluencerResponseDTO> findAll(InfluencerRequestDTO requestDTO);
+
+}

--- a/src/main/java/org/example/fanzip/influencer/service/InfluencerServiceImpl.java
+++ b/src/main/java/org/example/fanzip/influencer/service/InfluencerServiceImpl.java
@@ -1,0 +1,38 @@
+package org.example.fanzip.influencer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.influencer.domain.InfluencerVO;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
+import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
+import org.example.fanzip.influencer.mapper.InfluencerMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InfluencerServiceImpl implements InfluencerService {
+
+    private final InfluencerMapper influencerMapper;
+
+    @Override
+    public List<InfluencerResponseDTO> findAll(InfluencerRequestDTO requestDTO) {
+
+        // 1. 파라미터 구성
+        // userId와 category를 Map으로 묶어 보냄
+        Long userId = requestDTO.getUserId();
+        InfluencerCategory category = requestDTO.getCategory();
+
+        List<InfluencerVO> influencerList = influencerMapper.findAllFiltered(userId, category);
+
+
+        // 2. VO → ResponseDTO로 변환
+        // 각 InfluencerVO 객체를 InfluencerResponseDTO로 변환
+        // 최종적으로 클라이언트에게 반환될 형태의 리스트를 리턴
+        return influencerList.stream()
+                .map(InfluencerResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
+++ b/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.fanzip.influencer.mapper.InfluencerMapper">
+
+    <resultMap id="InfluencerResultMap" type="org.example.fanzip.influencer.domain.InfluencerVO">
+        <id column="influencer_id" property="influencerId"/>
+        <result column="influencer_name" property="influencerName"/>
+        <result column="category" property="category" javaType="org.example.fanzip.influencer.domain.enums.InfluencerCategory"/>
+        <result column="profile_image" property="profileImage"/>
+    </resultMap>
+
+    <select id="findAllFiltered" resultMap="InfluencerResultMap" parameterType="map">
+        SELECT
+        influencer_id, influencer_name, category, profile_image
+
+        FROM influencers
+
+        <where>
+            <!--
+            유저가 이미 구독중인 인플루언서는 제외하고 보여줌
+            AND
+            카테고리 필터링
+             -->
+            influencer_id NOT IN (
+            SELECT influencer_id
+            FROM memberships
+            WHERE user_id = #{userId}
+            )
+
+            <if test="category != null">
+                AND category = #{category}
+            </if>
+        </where>
+    </select>
+
+
+</mapper>

--- a/src/test/java/org/example/fanzip/influencer/mapper/InfluencerMapperTest.java
+++ b/src/test/java/org/example/fanzip/influencer/mapper/InfluencerMapperTest.java
@@ -1,0 +1,78 @@
+package org.example.fanzip.influencer.mapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.config.RootConfig;
+import org.example.fanzip.influencer.domain.InfluencerVO;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+@Transactional
+@Slf4j
+class InfluencerMapperTest {
+
+    @Autowired
+    private InfluencerMapper influencerMapper;
+
+    @Test
+    void findAllFiltered_withoutCategory_excludesSubscribedInfluencers() {
+
+        // 유저 ID 5는 influencer_id 2, 3을 구독 중(테스트 데이터)
+        long userId = 5L;
+
+        List<InfluencerVO> result = influencerMapper.findAllFiltered(userId, null);
+        log.info("!!!!! 조회 결과 (카테고리 지정 X) !!!!!: {}", result);
+
+        // 총 인플루언서 7명 중, 2명 구독 → 5명 나와야 함
+        assertEquals(5, result.size());
+
+        // 구독한 influencer_id 2, 3이 포함되어 있지 않아야 함
+        assertFalse(result.stream().anyMatch(i -> i.getInfluencerId() == 2L));
+        assertFalse(result.stream().anyMatch(i -> i.getInfluencerId() == 3L));
+    }
+
+    @Test
+    void findAllFiltered_withCategory_excludesSubscribedInfluencers() {
+        // 유저 ID 5는 influencer_id 2, 3 구독 중(테스트 데이터)
+
+        long userId = 5L;
+        InfluencerCategory category = InfluencerCategory.ETC;
+
+        List<InfluencerVO> result = influencerMapper.findAllFiltered(userId, category);
+        log.info("!!!!! 조회 결과 (카테고리=ETC) !!!!!: {}", result);
+
+        // ETC 카테고리 인플루언서: 1, 2, 100 → 그중 2는 구독중이므로 1, 100만 나와야 함
+        assertEquals(2, result.size());
+        List<Long> expectedIds = List.of(1L, 100L);
+
+        for (InfluencerVO vo : result) {
+            assertTrue(expectedIds.contains(vo.getInfluencerId()));
+            assertNotEquals(2L, vo.getInfluencerId()); // 구독 중이라 제외돼야 함
+        }
+    }
+
+    @Test
+    void findAllFiltered_withCategory_noMatchAfterExclusion() {
+        // 유저 ID 6은 influencer_id 1, 4 구독 중(테스트 데이터)
+        long userId = 6L;
+        InfluencerCategory category = InfluencerCategory.TRAVEL; // TRAVEL은 influencer_id 4번
+
+        List<InfluencerVO> result = influencerMapper.findAllFiltered(userId, category);
+        log.info("!!!!! 조회 결과 (카테고리=TRAVEL, userId=6) !!!!!: {}", result);
+
+        // 유저 6이 TRAVEL 카테고리인 4번 인플루언서를 구독 중 → 결과 없음
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/src/test/java/org/example/fanzip/influencer/service/InfluencerServiceImplTest.java
+++ b/src/test/java/org/example/fanzip/influencer/service/InfluencerServiceImplTest.java
@@ -1,0 +1,81 @@
+package org.example.fanzip.influencer.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.fanzip.config.RootConfig;
+import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
+import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+@Transactional
+@Slf4j
+class InfluencerServiceImplTest {
+
+    @Autowired
+    private InfluencerService influencerService;
+
+    @Test
+    void findAll_withoutCategory_excludesSubscribedInfluencers() {
+        // 5번 유저가 구독중인 인플루언서 제외하고 전체 조회하는 테스트
+        
+        // given
+        InfluencerRequestDTO requestDTO = InfluencerRequestDTO.builder()
+                .userId(5L)
+                .category(null) // 전체 조회
+                .build();
+
+        // when
+        List<InfluencerResponseDTO> result = influencerService.findAll(requestDTO);
+
+        // then
+        // 5번 유저는 influencer_id 2, 3번을 구독 중
+        List<Long> excluded = List.of(2L, 3L);
+
+        // 전체에서 2개 제외(2명 구독중이기 때문에)
+        assertEquals(5, result.size());
+
+        for (InfluencerResponseDTO dto : result) {
+            System.out.println("조회된 인플루언서 ID: " + dto.getInfluencerId());
+            assertFalse(excluded.contains(dto.getInfluencerId()));
+        }
+    }
+
+    @Test
+    void findAll_withCategory_excludesSubscribedInfluencers() {
+        // 5번 유저가 구독중인 인플루언서 제외하고 기타 카테고리 인플루언서 조회하는 테스트
+        
+        // given
+        InfluencerRequestDTO requestDTO = InfluencerRequestDTO.builder()
+                .userId(5L)
+                .category(InfluencerCategory.ETC)
+                .build();
+
+        // when
+        List<InfluencerResponseDTO> result = influencerService.findAll(requestDTO);
+
+        // then
+        // ETC 카테고리 중 2번은 구독 중이므로 제외
+        List<Long> expectedIds = List.of(1L, 100L); // 남아있는 ETC 인플루언서
+
+        assertEquals(expectedIds.size(), result.size());
+
+        for (InfluencerResponseDTO dto : result) {
+            System.out.println("조회된 인플루언서 ID: " + dto.getInfluencerId());
+            assertTrue(expectedIds.contains(dto.getInfluencerId()));
+        }
+    }
+
+
+}


### PR DESCRIPTION
- 제목 : feat(#31 ): 인플루언서 전체 목록 조회 API 구현

## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용

- 인플루언서 전체 목록 조회 구현
- 구독중인 인플루언서는 제외하고 조회
- 카테고리별 필터링 기능 구현

<br/>

## ➕ 이슈 링크

- Closes #31 

<br/>

## 📸 이미지 첨부

<br/>

## 📬 전달 사항
<br/>

## 🔧 앞으로의 과제

- 비밀번호 확인 후 탈퇴 처리 기능 추가 예정