### PR TITLE
[feat] 인플루언서 상세 조회 페이지

### DIFF
--- a/src/main/java/org/example/fanzip/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/config/RootConfig.java
@@ -20,7 +20,6 @@ import javax.sql.DataSource;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
-@ComponentScan(basePackages = {"org.example.fanzip"}, excludeFilters = @ComponentScan.Filter(org.springframework.stereotype.Controller.class))
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
 @MapperScan(basePackages = {
         "org.example.fanzip.fancard.mapper",
@@ -39,7 +38,7 @@ import javax.sql.DataSource;
         "org.example.fanzip.cart",
         "org.example.fanzip.membership.service",
         "org.example.fanzip.influencer.service"
-})
+}, excludeFilters = @ComponentScan.Filter(org.springframework.stereotype.Controller.class))
 public class RootConfig {
     @Value("${spring.datasource.driver-class-name}") String driver;
     @Value("${spring.datasource.url}") String url;

--- a/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
+++ b/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
@@ -3,14 +3,12 @@ package org.example.fanzip.influencer.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerDetailResponseDTO;
 import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
 import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
 import org.example.fanzip.influencer.service.InfluencerService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -41,5 +39,17 @@ public class InfluencerController {
 
         return ResponseEntity.ok(influencerList);
 
+    }
+
+    // 인플루언서 상세 조회
+    @GetMapping("/{influencerId}")
+    public ResponseEntity<InfluencerDetailResponseDTO> getDetail(
+            @PathVariable Long influencerId,
+            HttpServletRequest request) {
+
+        Long userId = (Long) request.getAttribute("userId");
+
+        InfluencerDetailResponseDTO responseDTO = influencerService.findDetailed(userId, influencerId);
+        return ResponseEntity.ok(responseDTO);
     }
 }

--- a/src/main/java/org/example/fanzip/influencer/domain/InfluencerVO.java
+++ b/src/main/java/org/example/fanzip/influencer/domain/InfluencerVO.java
@@ -17,4 +17,7 @@ public class InfluencerVO {
     private String influencerName;    // 인플루언서 이름
     private InfluencerCategory category; // 인플루언서 카테고리
     private String profileImage;      // 프로필 이미지 URL
+
+    private String coverImage;  // 상세 정보 조회시 상단에 뜨는 이미지
+    private String description; // 인플루언서 설명(팬미팅이나 공구 일정)
 }

--- a/src/main/java/org/example/fanzip/influencer/dto/InfluencerDetailResponseDTO.java
+++ b/src/main/java/org/example/fanzip/influencer/dto/InfluencerDetailResponseDTO.java
@@ -1,0 +1,30 @@
+package org.example.fanzip.influencer.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.fanzip.influencer.domain.InfluencerVO;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class InfluencerDetailResponseDTO {
+
+    private Long influencerId;
+    private String influencerName;
+    private String coverImage;
+    private String description;
+
+
+    public static InfluencerDetailResponseDTO from(InfluencerVO influencerVO){
+        return InfluencerDetailResponseDTO.builder()
+                .influencerId(influencerVO.getInfluencerId())
+                .influencerName(influencerVO.getInfluencerName())
+                .coverImage(influencerVO.getCoverImage())
+                .description(influencerVO.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
+++ b/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.example.fanzip.influencer.domain.InfluencerVO;
 import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerDetailResponseDTO;
 
 import java.util.List;
 
@@ -12,4 +13,8 @@ public interface InfluencerMapper {
 
     List<InfluencerVO> findAllFiltered(@Param("userId") Long userId,
                                        @Param("category") InfluencerCategory category);
+
+    InfluencerVO findDetailed(@Param("influencerId") Long influencerId);
+
+
 }

--- a/src/main/java/org/example/fanzip/influencer/service/InfluencerService.java
+++ b/src/main/java/org/example/fanzip/influencer/service/InfluencerService.java
@@ -1,6 +1,7 @@
 package org.example.fanzip.influencer.service;
 
 
+import org.example.fanzip.influencer.dto.InfluencerDetailResponseDTO;
 import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
 import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
 
@@ -10,4 +11,5 @@ public interface InfluencerService {
 
     List<InfluencerResponseDTO> findAll(InfluencerRequestDTO requestDTO);
 
+    InfluencerDetailResponseDTO findDetailed(Long userId, Long influencerId);
 }

--- a/src/main/java/org/example/fanzip/influencer/service/InfluencerServiceImpl.java
+++ b/src/main/java/org/example/fanzip/influencer/service/InfluencerServiceImpl.java
@@ -3,10 +3,13 @@ package org.example.fanzip.influencer.service;
 import lombok.RequiredArgsConstructor;
 import org.example.fanzip.influencer.domain.InfluencerVO;
 import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
+import org.example.fanzip.influencer.dto.InfluencerDetailResponseDTO;
 import org.example.fanzip.influencer.dto.InfluencerRequestDTO;
 import org.example.fanzip.influencer.dto.InfluencerResponseDTO;
 import org.example.fanzip.influencer.mapper.InfluencerMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +20,7 @@ public class InfluencerServiceImpl implements InfluencerService {
 
     private final InfluencerMapper influencerMapper;
 
+    // 전체 목록 조회
     @Override
     public List<InfluencerResponseDTO> findAll(InfluencerRequestDTO requestDTO) {
 
@@ -34,5 +38,20 @@ public class InfluencerServiceImpl implements InfluencerService {
         return influencerList.stream()
                 .map(InfluencerResponseDTO::from)
                 .collect(Collectors.toList());
+    }
+
+    // 상세 조회
+    @Override
+    public InfluencerDetailResponseDTO findDetailed(Long userId, Long influencerId) {
+
+        // 인플루언서Id로 DB 조회하고 DTO로 변환해서 클라로 보내기
+        InfluencerVO influencerDetail = influencerMapper.findDetailed(influencerId);
+
+        // 예외
+        if (influencerDetail == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 인플루언서를 찾을 수 없습니다.");
+        }
+
+        return InfluencerDetailResponseDTO.from(influencerDetail);
     }
 }

--- a/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
+++ b/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
@@ -12,6 +12,14 @@
         <result column="profile_image" property="profileImage"/>
     </resultMap>
 
+    <resultMap id="InfluencerDetailResultMap" type="org.example.fanzip.influencer.domain.InfluencerVO">
+        <id column="influencer_id" property="influencerId"/>
+        <result column="influencer_name" property="influencerName"/>
+        <result column="cover_image" property="coverImage"/>
+        <result column="description" property="description"/>
+
+    </resultMap>
+
     <select id="findAllFiltered" resultMap="InfluencerResultMap" parameterType="map">
         SELECT
         influencer_id, influencer_name, category, profile_image
@@ -34,6 +42,19 @@
                 AND category = #{category}
             </if>
         </where>
+    </select>
+
+
+    <select id="findDetailed" resultMap="InfluencerResultMap" parameterType="map">
+
+    select
+        influencer_id, influencer_name, cover_image, description
+
+    from
+        influencers
+
+    WHERE
+        influencer_id = #{influencerId}
     </select>
 
 

--- a/src/test/java/org/example/fanzip/influencer/mapper/InfluencerMapperTest.java
+++ b/src/test/java/org/example/fanzip/influencer/mapper/InfluencerMapperTest.java
@@ -7,6 +7,7 @@ import org.example.fanzip.influencer.domain.enums.InfluencerCategory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ContextConfiguration(classes = RootConfig.class)
 @Transactional
 @Slf4j
+@ActiveProfiles("test") // 또는 VM 옵션: -Dspring.profiles.active=test
 class InfluencerMapperTest {
 
     @Autowired
@@ -75,4 +77,17 @@ class InfluencerMapperTest {
         assertTrue(result.isEmpty());
     }
 
+
+    @Test
+    void findDetailed_shouldReturnInfluencerDetail_whenIdExists() {
+
+        Long influencerId = 1L; // influencerId: 1번인 인플루언서 조회
+
+        InfluencerVO result = influencerMapper.findDetailed(influencerId);
+
+        assertNotNull(result);
+        log.info("상세 조회 결과: {}", result);
+        assertEquals(influencerId, result.getInfluencerId());
+        assertNotNull(result.getDescription());
+    }
 }

--- a/src/test/java/org/example/fanzip/influencer/service/InfluencerServiceImplTest.java
+++ b/src/test/java/org/example/fanzip/influencer/service/InfluencerServiceImplTest.java
@@ -77,5 +77,19 @@ class InfluencerServiceImplTest {
         }
     }
 
+    @Test
+    void findDetailed_shouldReturnInfluencerDetail_whenExists() {
 
+        Long userId = 5L;
+        Long influencerId = 1L;
+
+        var result = influencerService.findDetailed(userId, influencerId);
+
+        assertNotNull(result);
+        log.info("상세 조회 결과: {}", result);
+
+        assertEquals(influencerId, result.getInfluencerId());
+        assertNotNull(result.getInfluencerName());
+        assertNotNull(result.getDescription());
+    }
 }

--- a/src/test/java/org/example/fanzip/payment/config/RootConfigTest.java
+++ b/src/test/java/org/example/fanzip/payment/config/RootConfigTest.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.example.fanzip.config.RootConfig;
+import org.example.fanzip.config.YamlPropertySourceFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
- 제목 : feat(#50 ): 인플루언서 상제 조회 API 구현  
## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용

- 원하는 인플루언서 클릭 시 상세 내용 조회 구현

<br/>

## ➕ 이슈 링크

- Closes #50 

<br/>

## 📸 이미지 첨부

<br/>

## 📬 전달 사항

<br/>

## 🔧 앞으로의 과제