### PR TITLE
[feat] 팬미팅 좌석 예약 및 예약 취소 API 구현

### DIFF
--- a/src/main/java/org/example/fanzip/meeting/controller/FanMeetingReservationController.java
+++ b/src/main/java/org/example/fanzip/meeting/controller/FanMeetingReservationController.java
@@ -1,0 +1,37 @@
+package org.example.fanzip.meeting.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.meeting.dto.FanMeetingReservationResponseDTO;
+import org.example.fanzip.meeting.service.FanMeetingReservationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fan-meetings")
+public class FanMeetingReservationController {
+
+    private final FanMeetingReservationService reservationService;
+
+    @PostMapping("/{meetingId}/seats/{seatId}/reservation")
+    public FanMeetingReservationResponseDTO reserve(
+            @PathVariable Long meetingId,
+            @PathVariable Long seatId,
+            HttpServletRequest request) {
+
+        Long userId = (Long) request.getAttribute("userId");   // 인터셉터에서 넣어줌
+        return reservationService.reserveSeat(meetingId, seatId, userId);
+    }
+
+    @DeleteMapping("/{meetingId}/reservation")
+    public ResponseEntity<Void> cancelReservation(
+            @PathVariable Long meetingId,
+            HttpServletRequest request) {
+
+        Long userId = (Long) request.getAttribute("userId");
+        reservationService.cancelReservation(meetingId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/example/fanzip/meeting/domain/FanMeetingReservationVO.java
+++ b/src/main/java/org/example/fanzip/meeting/domain/FanMeetingReservationVO.java
@@ -1,0 +1,21 @@
+package org.example.fanzip.meeting.domain;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class FanMeetingReservationVO {
+    private Long reservationId;
+    private Long meetingId;
+    private Long userId;
+    private Long seatId;
+    private String reservationNumber;
+    private String qrCode;
+    private ReservationStatus status;
+    private LocalDateTime reservedAt;
+    private LocalDateTime cancelledAt;
+    private LocalDateTime usedAt;
+
+
+}

--- a/src/main/java/org/example/fanzip/meeting/domain/FanMeetingSeatVO.java
+++ b/src/main/java/org/example/fanzip/meeting/domain/FanMeetingSeatVO.java
@@ -1,0 +1,18 @@
+package org.example.fanzip.meeting.domain;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+public class FanMeetingSeatVO {
+    private Long seatId;
+    private Long meetingId;
+    private String seatNumber;
+    private String seatType;
+    private BigDecimal price;
+    private boolean reserved;  // DB에 reserved 컬럼 있어야 함
+    private int version;        // 낙관적 락용 버전 필드
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/fanzip/meeting/dto/FanMeetingReservationRequestDTO.java
+++ b/src/main/java/org/example/fanzip/meeting/dto/FanMeetingReservationRequestDTO.java
@@ -1,0 +1,14 @@
+package org.example.fanzip.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FanMeetingReservationRequestDTO {
+    private Long seatId;
+}

--- a/src/main/java/org/example/fanzip/meeting/dto/FanMeetingReservationResponseDTO.java
+++ b/src/main/java/org/example/fanzip/meeting/dto/FanMeetingReservationResponseDTO.java
@@ -1,0 +1,19 @@
+package org.example.fanzip.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.fanzip.meeting.domain.ReservationStatus;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FanMeetingReservationResponseDTO {
+    private Long reservationId;
+    private String reservationNumber;
+    private String qrCode;
+    private ReservationStatus status;
+    private Long seatId;
+}

--- a/src/main/java/org/example/fanzip/meeting/mapper/FanMeetingReservationMapper.java
+++ b/src/main/java/org/example/fanzip/meeting/mapper/FanMeetingReservationMapper.java
@@ -1,0 +1,22 @@
+package org.example.fanzip.meeting.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.fanzip.meeting.domain.FanMeetingReservationVO;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface FanMeetingReservationMapper {
+    int insertReservation(FanMeetingReservationVO reservation);
+    boolean existByUserAndMeeting(@Param("userId") Long userId, @Param("meetingId") Long meetingId);
+
+
+    FanMeetingReservationVO findByUserAndMeeting(@Param("userId") Long userId, @Param("meetingId") Long meetingId);
+
+    int updateStatusToCanceled(
+            @Param("reservationId") Long reservationId,
+            @Param("cancelledAt") LocalDateTime cancelledAt
+    );
+
+}

--- a/src/main/java/org/example/fanzip/meeting/mapper/FanMeetingSeatMapper.java
+++ b/src/main/java/org/example/fanzip/meeting/mapper/FanMeetingSeatMapper.java
@@ -1,0 +1,19 @@
+package org.example.fanzip.meeting.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.example.fanzip.meeting.domain.FanMeetingSeatVO;
+
+import java.util.List;
+
+public interface FanMeetingSeatMapper {
+    List<FanMeetingSeatVO> findByMeetingId(@Param("meetingId") Long meetingId);
+    int updateSeatReservation(@Param("seatId") Long seatId, @Param("reserved") boolean reserved);
+    // 낙관적 락 테스트
+    FanMeetingSeatVO findById(@Param("seatId") Long seatId);
+    int updateSeatWithVersionCheck(
+            @Param("seatId") Long seatId,
+            @Param("reserved") boolean reserved,
+            @Param("version") int version
+    );
+
+}

--- a/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationService.java
+++ b/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationService.java
@@ -1,0 +1,8 @@
+package org.example.fanzip.meeting.service;
+
+import org.example.fanzip.meeting.dto.FanMeetingReservationResponseDTO;
+
+public interface FanMeetingReservationService {
+    FanMeetingReservationResponseDTO reserveSeat(Long meetingId, Long seatId, Long userId);
+    void cancelReservation(Long meetingId, Long userId);
+}

--- a/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationServiceImpl.java
+++ b/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationServiceImpl.java
@@ -1,0 +1,79 @@
+package org.example.fanzip.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.meeting.domain.FanMeetingReservationVO;
+import org.example.fanzip.meeting.domain.FanMeetingSeatVO;
+import org.example.fanzip.meeting.domain.ReservationStatus;
+import org.example.fanzip.meeting.dto.FanMeetingReservationResponseDTO;
+import org.example.fanzip.meeting.mapper.FanMeetingReservationMapper;
+import org.example.fanzip.meeting.mapper.FanMeetingSeatMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FanMeetingReservationServiceImpl implements FanMeetingReservationService {
+
+    private final FanMeetingReservationMapper reservationMapper;
+    private final FanMeetingSeatMapper seatMapper;
+
+    @Override
+    @Transactional
+    public FanMeetingReservationResponseDTO reserveSeat(Long meetingId, Long seatId, Long userId) {
+
+        // 이미 이 팬미팅을 예약했는지 확인
+        if (reservationMapper.existByUserAndMeeting(userId, meetingId)) {
+            throw new IllegalStateException("이미 예약한 팬미팅입니다.");
+        }
+
+        // 현재 좌석 정보 조회 (version 포함)
+        FanMeetingSeatVO seat = seatMapper.findById(seatId);
+        System.out.println("seat version = " + seat.getVersion());
+        if (seat == null || seat.isReserved()) {
+            throw new IllegalStateException("존재하지 않거나 이미 예약된 좌석입니다.");
+        }
+
+        // 낙관적 락 기반 업데이트 시도
+        int updated = seatMapper.updateSeatWithVersionCheck(seatId, true, seat.getVersion());
+        if (updated == 0) {
+            throw new IllegalStateException("좌석 예약 실패: 다른 유저가 먼저 예약했을 수 있습니다.");
+        }
+
+        // 예약 객체 생성 및 저장
+        FanMeetingReservationVO vo = new FanMeetingReservationVO();
+        vo.setMeetingId(meetingId);
+        vo.setUserId(userId);
+        vo.setSeatId(seatId);
+        vo.setReservationNumber(UUID.randomUUID().toString());
+        vo.setQrCode("QR-" + UUID.randomUUID());
+        vo.setStatus(ReservationStatus.RESERVED);
+        vo.setReservedAt(LocalDateTime.now());
+
+        reservationMapper.insertReservation(vo);
+
+        // 응답 반환
+        return new FanMeetingReservationResponseDTO(
+                vo.getReservationId(),
+                vo.getReservationNumber(),
+                vo.getQrCode(),
+                vo.getStatus(),
+                vo.getSeatId()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void cancelReservation(Long meetingId, Long userId) {
+        FanMeetingReservationVO reservation = reservationMapper.findByUserAndMeeting(userId, meetingId);
+
+        if (reservation == null) {
+            throw new IllegalStateException("예약 내역이 존재하지 않습니다.");
+        }
+
+        reservationMapper.updateStatusToCanceled(reservation.getReservationId(), LocalDateTime.now());
+        seatMapper.updateSeatReservation(reservation.getSeatId(), false);
+    }
+}

--- a/src/main/resources/org/example/fanzip/meeting/mapper/FanMeetingReservationMapper.xml
+++ b/src/main/resources/org/example/fanzip/meeting/mapper/FanMeetingReservationMapper.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.fanzip.meeting.mapper.FanMeetingReservationMapper">
+
+    <select id="existByUserAndMeeting" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM fan_meeting_reservations
+            WHERE user_id = #{userId}
+              AND meeting_id = #{meetingId}
+              AND status = 'RESERVED'
+        )
+    </select>
+
+    <insert id="insertReservation"
+            parameterType="org.example.fanzip.meeting.domain.FanMeetingReservationVO"
+            useGeneratedKeys="true" keyProperty="reservationId">
+        INSERT INTO fan_meeting_reservations (
+            meeting_id, user_id, seat_id,
+            reservation_number, qr_code,
+            status, reserved_at
+        ) VALUES (
+                     #{meetingId}, #{userId}, #{seatId},
+                     #{reservationNumber}, #{qrCode},
+                     #{status}, #{reservedAt}
+                 )
+    </insert>
+
+    <select id="findByUserMeetingAndSeat" resultType="org.example.fanzip.meeting.domain.FanMeetingReservationVO">
+        SELECT * FROM fan_meeting_reservations
+        WHERE user_id = #{userId}
+          AND meeting_id = #{meetingId}
+          AND seat_id = #{seatId}
+    </select>
+
+    <update id="updateStatusToCanceled">
+        UPDATE fan_meeting_reservations
+        SET status = 'CANCELED',
+            cancelled_at = #{cancelledAt}
+        WHERE reservation_id = #{reservationId}
+    </update>
+
+    <select id="findByUserAndMeeting" resultType="org.example.fanzip.meeting.domain.FanMeetingReservationVO">
+        SELECT * FROM fan_meeting_reservations
+        WHERE user_id = #{userId}
+          AND meeting_id = #{meetingId}
+          AND status = 'RESERVED'
+    </select>
+
+</mapper>

--- a/src/main/resources/org/example/fanzip/meeting/mapper/FanMeetingSeatMapper.xml
+++ b/src/main/resources/org/example/fanzip/meeting/mapper/FanMeetingSeatMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.fanzip.meeting.mapper.FanMeetingSeatMapper">
+
+    <select id="findByMeetingId"
+            resultType="org.example.fanzip.meeting.domain.FanMeetingSeatVO"
+            parameterType="long">
+        SELECT *
+        FROM fan_meeting_seats
+        WHERE meeting_id = #{meetingId}
+        ORDER BY seat_number
+    </select>
+
+    <update id="updateSeatReservation" parameterType="map">
+        UPDATE fan_meeting_seats
+        SET is_reserved = #{reserved}
+        WHERE seat_id     = #{seatId}
+    </update>
+
+
+    <resultMap id="FanMeetingSeatResultMap" type="org.example.fanzip.meeting.domain.FanMeetingSeatVO">
+        <id property="seatId" column="seat_id"/>
+        <result property="meetingId" column="meeting_id"/>
+        <result property="seatNumber" column="seat_number"/>
+        <result property="seatType" column="seat_type"/>
+        <result property="price" column="price"/>
+        <result property="reserved" column="is_reserved"/>
+        <result property="version" column="version"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+
+    <select id="findById" resultMap="FanMeetingSeatResultMap">
+        SELECT
+            seat_id,
+            meeting_id,
+            seat_number,
+            seat_type,
+            price,
+            is_reserved,
+            version,
+            created_at
+        FROM fan_meeting_seats
+        WHERE seat_id = #{seatId}
+    </select>
+
+
+    <!-- 낙관적 락을 위한 update -->
+    <update id="updateSeatWithVersionCheck">
+        UPDATE fan_meeting_seats
+        SET is_reserved = TRUE,
+            version = version + 1
+        WHERE seat_id = #{seatId}
+          AND version = #{version}
+          AND is_reserved = FALSE
+    </update>
+
+</mapper>


### PR DESCRIPTION

## 📌 개요
팬미팅 좌석을 예약하고 취소할 수 있는 API를 구현했습니다.  
동시성 문제를 방지하기 위해 낙관적 락(Optimistic Lock)을 활용하여 좌석 선점 로직을 처리했습니다.


## 🛠 작업내용

- **FanMeetingReservationController 생성**
  - `POST /api/fan-meetings/{meetingId}/seats/{seatId}/reservation`  
    → 팬미팅 좌석 예약 요청 처리
  - `DELETE /api/fan-meetings/{meetingId}/reservation`  
    → 팬미팅 예약 취소 처리

- **FanMeetingReservationService 인터페이스 정의 및 구현**
  - 이미 예약한 사용자에 대한 예외 처리
  - 좌석 조회 및 낙관적 락 기반 선점 처리
  - 예약 정보 저장 및 QR 코드 발급
  - 예약 취소 시 상태 변경 및 좌석 반영

- **SeatMapper**
  - `findById`
  - `updateSeatWithVersionCheck`
  - `updateSeatReservation`

- **ReservationMapper**
  - `existByUserAndMeeting`
  - `insertReservation`
  - `findByUserAndMeeting`
  - `updateStatusToCanceled`

---

### 🔍 참고

- 현재 낙관적 락 기반 선점 방식만 적용됨
- 추후 테스트 예정:
  - 비관적 락(Pessimistic Lock) 방식과 비교 테스트
  - Redis 기반 분산 락(Redisson) 적용 시도
- K6를 활용한 부하 테스트 및 동시 요청 시 시나리오 검증 예정