### PR TITLE
[Fix](#61) cicd deployment timeout

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-2
+          aws-region: ap-northeast-2
 
       - name: Add GitHub IP to AWS
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ bin/
 
 # workspace.xml 로컬 설정 파일
 .idea/workspace.xml
+
+### 설정 파일 ###
+src/main/resources/application.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
  ## 🔘 Part

  - [ ] FE
  - [x] BE
  - [ ] Docs
  - [x] Chore

  <br/>                                                                                                                                                                                                                                                                                                             

  ## 🔎 작업 내용
  - GitHub Actions 워크플로우 AWS 리전을 ap-southeast-2(시드니)에서 ap-northeast-2(서울)로 변경
  - application.yml을 .gitignore에 추가
  - SSH 연결 타임아웃 오류 해결

  <br/>                                                                                                                                                                                                                                                                                                             

  ## ➕ 이슈 링크
  - Closes #61

  <br/>                                                                                                                                                                                                                                                                                                             
  ## 📬 전달 사항

 
  <br/>                                                                                                                                                                                                                                                                                                             

  ## 🔧 앞으로의 과제

  - GitHub Secrets 업데이트 후 배포 테스트 필요