### PR TITLE
[feat] S3 활용 인플루언서 프로필 이미지 및 팬카드 이미지 업로드 및 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,14 @@ dependencies {
   implementation("org.springframework.security:spring-security-web:${springSecurityVersion}")
   implementation("org.springframework.security:spring-security-config:${springSecurityVersion}")
   implementation("org.springframework.security:spring-security-core:${springSecurityVersion}")
+
+  // AWS S3
+  implementation 'com.amazonaws:aws-java-sdk-s3:1.12.660'
+
+  // 파일 업로드 처리용 (multipart resolver 사용 시 필수)
+  implementation 'commons-fileupload:commons-fileupload:1.4'
+
+  implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 }
 
 test {

--- a/src/main/java/org/example/fanzip/global/config/RedissonConfig.java
+++ b/src/main/java/org/example/fanzip/global/config/RedissonConfig.java
@@ -10,10 +10,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RedissonConfig {
 
-    @Value("${redis.host}")
+    @Value("${spring.redis.host}")
     private String redisHost;
 
-    @Value("${redis.port}")
+    @Value("${spring.redis.port}")
     private int redisPort;
 
     @Bean

--- a/src/main/java/org/example/fanzip/global/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/global/config/RootConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
 import javax.sql.DataSource;
 
@@ -83,4 +84,12 @@ public class RootConfig {
 //    public ObjectMapper objectMapper() {
 //        return new ObjectMapper();
 //    }
+
+    @Bean
+    public CommonsMultipartResolver multipartResolver() {
+        CommonsMultipartResolver resolver = new CommonsMultipartResolver();
+        resolver.setDefaultEncoding("utf-8");
+        resolver.setMaxUploadSize(10 * 1024 * 1024); // 10MB
+        return resolver;
+    }
 }

--- a/src/main/java/org/example/fanzip/global/s3/AwsS3Config.java
+++ b/src/main/java/org/example/fanzip/global/s3/AwsS3Config.java
@@ -1,0 +1,50 @@
+package org.example.fanzip.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import jakarta.annotation.PostConstruct;
+
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Value("${aws.access-key}")
+    private String accessKey;
+
+    @Value("${aws.secret-key}")
+    private String secretKey;
+
+
+    @PostConstruct
+    public void checkKeys() {
+        System.out.println("✅ Access Key: " + accessKey);
+        System.out.println("✅ Secret Key: " + secretKey);
+        System.out.println("✅ Region: " + region);
+    }
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        System.out.println("== AWS S3 설정 확인 ==");
+        System.out.println("Region: " + region);
+        System.out.println("Access Key: " + accessKey);
+        System.out.println("Secret Key: " + secretKey);
+
+
+
+        BasicAWSCredentials creds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(creds))
+                .build();
+    }
+}

--- a/src/main/java/org/example/fanzip/global/s3/S3Controller.java
+++ b/src/main/java/org/example/fanzip/global/s3/S3Controller.java
@@ -1,0 +1,194 @@
+package org.example.fanzip.global.s3;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Api(
+        value = "S3 이미지 업로드",
+        description = "AWS S3에 프로필 이미지, 팬카드 이미지를 업로드/삭제하는 API 집합입니다."
+)
+@RestController
+@RequestMapping("/api/influencers")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    /**
+     * 1) 인플루언서 프로필 이미지 업로드
+     * 예) POST /api/{influencerId}/profile/image
+     */
+
+    @ApiOperation(
+            value = "인플루언서 프로필 이미지 업로드",
+            notes = """
+                        인플루언서 프로필 이미지를 업로드합니다.
+                        - `influencerId`는 URL 경로에 포함됩니다.
+                        - 업로드된 이미지는 S3 버킷 `fanzip`의 `influencer_profile/` 경로에 저장됩니다.
+                    
+                        [요청 예시]
+                        POST /api/influencers/5/profile/image
+                        Content-Type: application/json
+                    
+                        {
+                            "imageUrl": "https://fanzip.s3.ap-northeast-2.amazonaws.com/influencer_profile/uuid-or-filename.jpg"
+                        }
+                    
+                        [응답 예시]
+                        200 OK
+                    """)
+
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "업로드 성공 (이미지 URL 반환)"),
+            @ApiResponse(code = 400, message = "잘못된 요청(DTO 누락 또는 형식 오류)")
+    })
+
+    @PostMapping("/{influencerId}/profile/image")
+    public ResponseEntity<String> uploadProfileImage(
+            @PathVariable Long influencerId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        if (file.getSize() > 5 * 1024 * 1024) {
+            return ResponseEntity.badRequest().body("5MB 이하의 파일만 업로드할 수 있습니다.");
+        }
+
+        String imageUrl = s3Service.uploadProfileImage(file, influencerId);
+        return ResponseEntity.ok(imageUrl);
+    }
+
+    /**
+     * 2) 인플루언서 팬카드 이미지 업로드
+     * 예) POST /api/{influencerId}/fancard/image
+     */
+    @ApiOperation(
+            value = "인플루언서 팬카드 이미지 업로드",
+            notes = """
+                        인플루언서 팬카드 이미지를 업로드합니다.
+                        이 이미지는 팬카드 디자인 전반에 반영됩니다.
+                        - `influencerId`는 URL 경로에 포함됩니다.
+                        - 요청 바디에는 팬카드 이미지 URL 또는 관련 설정이 담긴 DTO를 전송합니다.
+
+                        [요청 예시]
+                        POST /api/influencers/5/fancard/image
+                        Content-Type: application/json
+
+                        {
+                             "imageUrl": "https://fanzip.s3.ap-northeast-2.amazonaws.com/fancard_image/1234abcd.jpg"
+                        }
+
+                        [응답 예시]
+                        200 OK
+                    """)
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "업로드 성공 (이미지 URL 반환)"),
+            @ApiResponse(code = 400, message = "잘못된 요청(DTO 누락 또는 형식 오류)")
+    })
+
+
+    @PostMapping("/{influencerId}/fancard/image")
+    public ResponseEntity<String> uploadFanCardImage(
+            @PathVariable Long influencerId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        if (file.getSize() > 5 * 1024 * 1024) {
+            return ResponseEntity.badRequest().body("5MB 이하의 파일만 업로드할 수 있습니다.");
+        }
+
+        String imageUrl = s3Service.uploadFanCardImage(file, influencerId);
+        return ResponseEntity.ok(imageUrl);
+    }
+
+    /**
+     * 3) 인플루언서 프로필 이미지 삭제
+     * 예) DELETE /api/influencers/{influencerId}/profile/image
+     */
+    @ApiOperation(
+            value = "인플루언서 프로필 이미지 삭제",
+            notes = """
+                    (현재 S3 삭제는 제외됨) 인플루언서의 현재 프로필 이미지를 삭제합니다.
+                    - `influencerId`를 통해 해당 인플루언서의 기존 이미지 URL을 조회 후, S3에서 삭제합니다.
+                    - 삭제 후 DB에서도 해당 이미지 URL 정보를 제거합니다.
+                    
+                    [요청 예시]
+                    DELETE /api/influencers/7/profile/image
+                    
+                    [응답 예시]
+                    204 No Content
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "삭제 성공 (No Content)"),
+            @ApiResponse(code = 404, message = "이미지가 존재하지 않음")
+    })
+    @DeleteMapping("/{influencerId}/profile/image")
+    public ResponseEntity<Void> deleteProfileImage(
+            @PathVariable Long influencerId
+    ) {
+        // 1. 현재 이미지 URL 조회
+        String existingImageUrl = s3Service.getCurrentProfileImageUrl(influencerId);
+
+        if (existingImageUrl == null || existingImageUrl.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // 2. S3에서 삭제
+//        s3Service.deleteS3Image(existingImageUrl);
+
+        // 3. DB URL 제거 (null 처리)
+        s3Service.updateProfileImageUrl(influencerId, null);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 4) 인플루언서 팬카드 이미지 삭제
+     * 예) DELETE /api/influencers/{influencerId}/fancard/image
+     */
+    @ApiOperation(
+            value = "인플루언서 팬카드 이미지 삭제",
+            notes = """
+                (현재 S3 삭제는 제외됨) 인플루언서의 현재 팬카드 이미지를 삭제합니다.
+                - `influencerId`를 통해 해당 인플루언서의 기존 팬카드 이미지 URL을 조회 후, S3에서 삭제합니다.
+                - 삭제 후 DB에서도 해당 팬카드 이미지 URL 정보를 제거합니다.
+                
+                [요청 예시]
+                DELETE /api/influencers/7/fancard/image
+                
+                [응답 예시]
+                204 No Content
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "삭제 성공 (No Content)"),
+            @ApiResponse(code = 404, message = "이미지가 존재하지 않음")
+    })
+    @DeleteMapping("/{influencerId}/fancard/image")
+
+
+    public ResponseEntity<Void> deleteFanCardImage(
+            @PathVariable Long influencerId
+    ) {
+        // 1. 현재 팬카드 이미지 URL 조회
+        String existingImageUrl = s3Service.getCurrentFanCardImageUrl(influencerId);
+
+        if (existingImageUrl == null || existingImageUrl.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // 2. S3에서 삭제
+//        s3Service.deleteS3Image(existingImageUrl);
+
+        // 3. DB URL 제거 (null 처리)
+        s3Service.updateFanCardImageUrl(influencerId, null);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/org/example/fanzip/global/s3/S3Service.java
+++ b/src/main/java/org/example/fanzip/global/s3/S3Service.java
@@ -1,0 +1,196 @@
+package org.example.fanzip.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.example.fanzip.influencer.mapper.InfluencerMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.UUID;
+import java.net.URL;
+
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    private final InfluencerMapper influencerMapper;
+
+    private static final String BUCKET_NAME = "fanzip"; // S3 버킷 이름
+    private static final String PROFILE_IMAGE_PATH = "influencer_profile";  // S3 버킷에 프로필 이미지가 저장될 경로
+    private static final String FANCARD_IMAGE_PATH = "fancard_image"; // S3 버킷에 팬카드 이미지가 저장될 경로
+
+
+    /**
+     * 1. 인플루언서 프로필 이미지 업로드
+     */
+
+    @Transactional
+    public String uploadProfileImage(MultipartFile file, Long influencerId) {
+        System.out.println("🔥 uploadProfileImage() 진입");
+        System.out.println("🔥 influencerId = " + influencerId);
+        System.out.println("🔥 file.isEmpty() = " + file.isEmpty());
+        System.out.println("🔥 file.originalName = " + file.getOriginalFilename());
+
+        String existingImageUrl = getCurrentProfileImageUrl(influencerId);
+        System.out.println("🔥 기존 이미지 URL: " + existingImageUrl);
+
+         // ✅ 기존 이미지가 있다면 삭제
+//        if (existingImageUrl != null && !existingImageUrl.isEmpty()) {
+//            deleteS3Image(existingImageUrl);
+//            System.out.println("🗑 기존 이미지 삭제 완료");
+//        }
+
+        String newImageUrl = uploadImage(file, PROFILE_IMAGE_PATH);
+        System.out.println("✅ S3 업로드 성공: " + newImageUrl);
+
+        updateProfileImageUrl(influencerId, newImageUrl);
+        System.out.println("✅ DB 업데이트 완료");
+
+        // ✅ 업데이트된 URL 직접 조회해서 확인해보기
+        String updatedImageUrl = getCurrentProfileImageUrl(influencerId);
+        System.out.println("🎯 업데이트 후 DB 조회한 이미지 URL: " + updatedImageUrl);
+
+        return newImageUrl;
+    }
+
+    /**
+     * 2. 팬카드 이미지 업로드
+     */
+    @Transactional
+    public String uploadFanCardImage(MultipartFile file, Long influencerId) {
+        System.out.println("🔥 uploadFanCardImage() 진입");
+        System.out.println("🔥 influencerId = " + influencerId);
+        System.out.println("🔥 file.isEmpty() = " + file.isEmpty());
+        System.out.println("🔥 file.originalName = " + file.getOriginalFilename());
+
+        // 기존 팬카드 이미지 URL 조회
+        String existingCardUrl = getCurrentFanCardImageUrl(influencerId);
+        System.out.println("🔥 기존 팬카드 이미지 URL: " + existingCardUrl);
+
+        // 기존 이미지가 있으면 삭제
+//        if (existingCardUrl != null && !existingCardUrl.isEmpty()) {
+//            deleteS3Image(existingCardUrl);
+//            System.out.println("🗑 기존 이미지 삭제 완료");
+//        }
+
+        // 새 이미지 업로드
+        String newCardUrl = uploadImage(file, FANCARD_IMAGE_PATH);
+        System.out.println("✅ S3 팬카드 업로드 성공: " + newCardUrl);
+
+        // DB 업데이트
+        updateFanCardImageUrl(influencerId, newCardUrl);
+        System.out.println("✅ DB 업데이트 완료");
+
+        return newCardUrl;
+    }
+    /**
+     * 3. 실제 S3에 이미지 업로드 처리
+     */
+    private String uploadImage(MultipartFile file, String directory) {
+        String fileName = createFileName(file.getOriginalFilename());
+        String key = directory + "/" + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(BUCKET_NAME, key, inputStream, metadata));
+            return amazonS3.getUrl(BUCKET_NAME, key).toString();
+        } catch (IOException e) {
+            throw new RuntimeException("S3 이미지 업로드 실패", e);
+        }
+    }
+
+    /**
+     * 4. 랜덤 파일명 생성
+     */
+    private String createFileName(String originalName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(originalName));
+    }
+
+    /**
+     * 5. 파일 확장자 유효성 검사
+     */
+    private String getFileExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            throw new IllegalArgumentException("잘못된 파일명입니다.");
+        }
+
+        String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+
+        // 허용할 확장자 목록 (소문자 기준)
+        List<String> allowedExtensions = List.of(".jpg", ".jpeg", ".png", ".heic");
+
+        if (!allowedExtensions.contains(extension)) {
+            throw new IllegalArgumentException("허용되지 않는 확장자입니다: " + extension);
+        }
+
+        return extension;
+    }
+
+    /**
+     * 6) 현재 인플루언서의 프로필 이미지 URL 조회 (DB에서)
+     */
+    public String getCurrentProfileImageUrl(Long influencerId) {
+        return influencerMapper.selectProfileImageUrl(influencerId);
+    }
+
+    /**
+     * 7) S3에 저장된 이미지를 삭제하는 메서드
+     * @param imageUrl 삭제할 이미지의 S3 URL
+     */
+//    public void deleteS3Image(final String imageUrl) {
+//        if (imageUrl == null || imageUrl.isEmpty()) return;
+//
+//        try {
+//            URL url = new URL(imageUrl);
+//            String imageKey = url.getPath().substring(1); // "/influencer_profile/abc.jpg" → "influencer_profile/abc.jpg"
+//
+//            amazonS3.deleteObject(BUCKET_NAME, imageKey);
+//
+//            if (amazonS3.doesObjectExist(BUCKET_NAME, imageKey)) {
+//                throw new RuntimeException("S3 이미지 삭제 실패: " + imageKey);
+//            }
+//        } catch (MalformedURLException e) {
+//            throw new RuntimeException("잘못된 S3 이미지 URL입니다: " + imageUrl);
+//        }
+//    }
+
+    /**
+     * 8) DB에서 프로필 이미지 URL null 처리
+     */
+
+    public void updateProfileImageUrl(Long influencerId, String newUrl) {
+        influencerMapper.updateProfileImageUrl(influencerId, newUrl);
+    }
+
+
+    /*
+    * 팬카드 이미지 조회
+    * */
+    public String getCurrentFanCardImageUrl(Long influencerId) {
+        return influencerMapper.selectFanCardImageUrl(influencerId);
+    }
+
+    /*
+    * 팬카드 이미지 업데이트
+    * */
+    public void updateFanCardImageUrl(Long influencerId, String newUrl) {
+        influencerMapper.updateFanCardImageUrl(influencerId, newUrl);
+    }
+
+}

--- a/src/main/java/org/example/fanzip/global/s3/S3Service.java
+++ b/src/main/java/org/example/fanzip/global/s3/S3Service.java
@@ -175,7 +175,7 @@ public class S3Service {
      */
 
     public void updateProfileImageUrl(Long influencerId, String newUrl) {
-        influencerMapper.updateProfileImageUrl(influencerId, newUrl);
+        influencerMapper.updateProfileImage(influencerId, newUrl);
     }
 
 

--- a/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
+++ b/src/main/java/org/example/fanzip/influencer/controller/InfluencerController.java
@@ -84,28 +84,28 @@ public class InfluencerController {
     }
 
     // 인플루언서 프로필 이미지 업로드
-    @PostMapping("/{influencerId}/profile/image")
-    public ResponseEntity<Void> updateProfileImage(
-            @PathVariable Long influencerId,
-            @RequestBody InfluencerProfileImgUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserPrincipal principal) {
-
-        Long userId = principal.getUserId();
-
-        influencerService.updateInfluencerProfileImage(influencerId, requestDTO, userId);
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/{influencerId}/profile/image")
+//    public ResponseEntity<Void> updateProfileImage(
+//            @PathVariable Long influencerId,
+//            @RequestBody InfluencerProfileImgUpdateRequestDTO requestDTO,
+//            @AuthenticationPrincipal CustomUserPrincipal principal) {
+//
+//        Long userId = principal.getUserId();
+//
+//        influencerService.updateInfluencerProfileImage(influencerId, requestDTO, userId);
+//        return ResponseEntity.ok().build();
+//    }
 
     // 인플루언서 팬카드 이미지 업로드 (해당 인플루언서의 모든 활성 팬카드 디자인 업데이트)
-    @PostMapping("/{influencerId}/fancard/image")
-    public ResponseEntity<Void> updateFanCardImage(
-            @PathVariable Long influencerId,
-            @RequestBody InfluencerFanCardImageUpdateRequestDTO requestDTO,
-            @AuthenticationPrincipal CustomUserPrincipal principal) {
-
-        Long userId = principal.getUserId();
-
-        influencerService.updateInfluencerFanCardImage(influencerId, requestDTO, userId);
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/{influencerId}/fancard/image")
+//    public ResponseEntity<Void> updateFanCardImage(
+//            @PathVariable Long influencerId,
+//            @RequestBody InfluencerFanCardImageUpdateRequestDTO requestDTO,
+//            @AuthenticationPrincipal CustomUserPrincipal principal) {
+//
+//        Long userId = principal.getUserId();
+//
+//        influencerService.updateInfluencerFanCardImage(influencerId, requestDTO, userId);
+//        return ResponseEntity.ok().build();
+//    }
 }

--- a/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
+++ b/src/main/java/org/example/fanzip/influencer/mapper/InfluencerMapper.java
@@ -24,7 +24,20 @@ public interface InfluencerMapper {
                       @Param("description") String description,
                       @Param("category") InfluencerCategory category);
 
+    // 프로필 이미지 조회
+    String selectProfileImageUrl(@Param("influencerId") Long influencerId);
+
     // 프로필 이미지 수정
     int updateProfileImage(@Param("influencerId") Long influencerId,
                            @Param("profileImage") String profileImage);
+
+    // 팬카드 이미지 수정
+    int updateFanCardImageUrl(@Param("influencerId") Long influencerId,
+                              @Param("fanCardImage") String fanCardImage);
+
+    // 팬카드 이미지 조회
+    String selectFanCardImageUrl(@Param("influencerId") Long influencerId);
+
+
+
 }

--- a/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
+++ b/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
@@ -57,7 +57,6 @@
         SELECT influencer_id, influencer_name, category, profile_image, description
         FROM influencers
         WHERE influencer_id = #{influencerId}
-          AND deleted_at IS NULL
     </select>
 
     <!-- 마이페이지: 프로필 수정 -->

--- a/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
+++ b/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
@@ -76,4 +76,27 @@
             updated_at = NOW()
         WHERE influencer_id = #{influencerId}
     </update>
+
+    <!-- 팬카드 이미지 수정 -->
+    <update id="updateFanCardImageUrl" parameterType="map">
+        UPDATE influencers
+        SET fancard_image = #{fanCardImage},
+            updated_at = NOW()
+        WHERE influencer_id = #{influencerId}
+    </update>
+
+    <!-- 팬카드 이미지 조회 -->
+    <select id="selectFanCardImageUrl" resultType="string" parameterType="long">
+        SELECT fancard_image
+        FROM influencers
+        WHERE influencer_id = #{influencerId}
+    </select>
+
+    <!-- 프로필 이미지 조회 -->
+    <select id="selectProfileImageUrl" resultType="string" parameterType="long">
+        SELECT profile_image
+        FROM influencers
+        WHERE influencer_id = #{influencerId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
- 제목 : feat(#73 ): S3 활용 이미지 업로드 및 수정 기능 구현
## 🔘 Part

- [ ] FE
- [X] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용

- 이미지 업로드 시 S3에 파일 저장
- 저장된 이미지의 URL을 DB에 저장
- 기존 이미지가 있을 경우, S3에서 삭제 후 새 이미지 업로드

<br/>

## ➕ 이슈 링크

- Closes #73 

<br/>


<br/>

## 📬 전달 사항
- 현재는 업로드 및 수정 기능만 구현

<br/>

## 🔧 앞으로의 과제

- 이미지 삭제 기능 추가 구현 예정