### PR TITLE
[feat] 마켓 정렬 기능 추가 

### DIFF
--- a/createTables.sql
+++ b/createTables.sql
@@ -148,6 +148,7 @@ CREATE TABLE products (
                           general_open_time DATETIME,
                           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                           updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                          categories JSON,
                           FOREIGN KEY (influencer_id) REFERENCES influencers(influencer_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/src/main/java/org/example/fanzip/market/controller/MarketController.java
+++ b/src/main/java/org/example/fanzip/market/controller/MarketController.java
@@ -31,18 +31,21 @@ public class MarketController {
     // 전체 상품 조회
     @GetMapping("/products")
     public List<ProductListDto> getProducts(
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
             @RequestParam(value = "limit", defaultValue = "20") int limit,
             @RequestParam(value = "lastProductId", required = false) Long lastProductId,
-            @RequestParam(value = "q", required = false) String keyword
+            @RequestParam(value = "q", required = false) String keyword,
+            @RequestParam(value="sort", defaultValue = "recommended") String sort,
+            @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "onlySubscribed", required = false, defaultValue = "false") boolean onlySubscribed
     ) {
+        Long userId = customUserPrincipal.getUserId();
+
         if(keyword != null && !keyword.isBlank()) {
-            return marketService.searchProducts(keyword, lastProductId, limit);
+            return marketService.searchProducts(userId, keyword, lastProductId, limit);
         }
 
-        if (lastProductId == null) {
-            return marketService.getAllProducts(limit);
-        }
-        return marketService.getProductsAfter(lastProductId, limit);
+        return marketService.getProducts(userId, lastProductId, limit, sort, category, onlySubscribed);
     }
 
     // 상세 상품 조회

--- a/src/main/java/org/example/fanzip/market/controller/MarketController.java
+++ b/src/main/java/org/example/fanzip/market/controller/MarketController.java
@@ -42,7 +42,7 @@ public class MarketController {
         Long userId = customUserPrincipal.getUserId();
 
         if(keyword != null && !keyword.isBlank()) {
-            return marketService.searchProducts(userId, keyword, lastProductId, limit);
+            return marketService.searchProducts(userId, keyword, lastProductId, limit, sort, category);
         }
 
         return marketService.getProducts(userId, lastProductId, limit, sort, category, onlySubscribed);

--- a/src/main/java/org/example/fanzip/market/domain/MarketVO.java
+++ b/src/main/java/org/example/fanzip/market/domain/MarketVO.java
@@ -22,6 +22,7 @@ public class MarketVO {
     private BigDecimal discountedPrice;
     private BigDecimal discountRate;
     private String thumbnailImage;
+    private String categories;
 
     private Integer stock;
     private Boolean isSoldOut;

--- a/src/main/java/org/example/fanzip/market/domain/enums/ProductCategory.java
+++ b/src/main/java/org/example/fanzip/market/domain/enums/ProductCategory.java
@@ -1,0 +1,19 @@
+package org.example.fanzip.market.domain.enums;
+
+public enum ProductCategory {
+    APPAREL,          // 의류
+    BEAUTY,           // 뷰티
+    FOOD,             // 식품
+    INFANT,           // 유아
+    PETS,             // 반려동물
+    ELECTRONICS,      // 가전
+    FURNITURE,        // 가구
+    INTERIOR,         // 인테리어
+    KITCHEN,          // 주방
+    SPORTS_LEISURE,   // 스포츠/레저
+    AUTOMOTIVE,       // 자동차
+    LIFESTYLE,        // 생활
+    MUSICAL_INSTRUMENTS, // 악기
+    TRAVEL,           // 여행
+    OTHER             // 기타
+}

--- a/src/main/java/org/example/fanzip/market/dto/ProductDetailDto.java
+++ b/src/main/java/org/example/fanzip/market/dto/ProductDetailDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.example.fanzip.market.domain.enums.ProductCategory;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -33,4 +34,5 @@ public class ProductDetailDto {
     private LocalDateTime openTime;
     private boolean isAvailable;
 
+    private String categories;
 }

--- a/src/main/java/org/example/fanzip/market/dto/ProductListDto.java
+++ b/src/main/java/org/example/fanzip/market/dto/ProductListDto.java
@@ -4,8 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.example.fanzip.market.domain.enums.ProductCategory;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Data
 @Builder
@@ -19,4 +21,5 @@ public class ProductListDto {
     private BigDecimal discountRate;
     private String thumbnailImage;
     private Integer stock;
+    private String categories;
 }

--- a/src/main/java/org/example/fanzip/market/mapper/MarketMapper.java
+++ b/src/main/java/org/example/fanzip/market/mapper/MarketMapper.java
@@ -33,7 +33,9 @@ public interface MarketMapper {
             @Param("userId") Long userId,
             @Param("keyword") String keyword,
             @Param("lastProductId") Long lastProductId,
-            @Param("limit") int limit
+            @Param("limit") int limit,
+            @Param("sort") String sort,
+            @Param("category") String category
     );
 
     // 재고 조회

--- a/src/main/java/org/example/fanzip/market/mapper/MarketMapper.java
+++ b/src/main/java/org/example/fanzip/market/mapper/MarketMapper.java
@@ -5,19 +5,21 @@ import org.apache.ibatis.annotations.Param;
 import org.example.fanzip.market.domain.MarketVO;
 import org.example.fanzip.market.dto.ProductDetailDto;
 import org.example.fanzip.market.dto.ProductListDto;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
 @Mapper
 public interface MarketMapper {
-    // 모든 상품 목록 조회 (limit 개수만큼)
-    List<ProductListDto> getAllProducts(
-            @Param("limit") int limit);
-
     // 마지막으로 가져온 productId 까지의 상품 조회
-    List<ProductListDto> getProductsAfter(
+    // sort: latest || priceAsc || recommended
+    List<ProductListDto> getProducts(
+            @Param("userId") Long userId,
             @Param("lastProductId") Long lastProductId,
-            @Param("limit") int limit
+            @Param("limit") int limit,
+            @Param("sort") String sort,
+            @Param("category") String category,
+            @Param("onlySubscribed") boolean onlySubscribed
     );
 
     // 상품 상세 페이지 조회
@@ -26,14 +28,9 @@ public interface MarketMapper {
             @Param("userId") Long userId
     );
 
-    // 검색 기능 (1페이지)
-    List<ProductListDto> searchProducts(
-            @Param("keyword") String keyword,
-            @Param("limit") int limit
-    );
-
     // 검색 기능
-    List<ProductListDto> searchProductsAfter(
+    List<ProductListDto> searchProducts(
+            @Param("userId") Long userId,
             @Param("keyword") String keyword,
             @Param("lastProductId") Long lastProductId,
             @Param("limit") int limit
@@ -42,10 +39,10 @@ public interface MarketMapper {
     // 재고 조회
     int getStock(
             @Param("productId") Long productId);
-    
+
     // 상품 추가
     int insertProduct(MarketVO marketVO);
-    
+
     // 마지막 삽입된 상품 ID 조회
     Long getLastInsertId();
 }

--- a/src/main/java/org/example/fanzip/market/service/MarketService.java
+++ b/src/main/java/org/example/fanzip/market/service/MarketService.java
@@ -16,7 +16,8 @@ public interface MarketService {
     ProductDetailDto getProductDetail(Long userId, Long productId);
 
     // 검색
-    List<ProductListDto> searchProducts(Long userId, String keyword, Long lastProductId, int limit);
+    List<ProductListDto> searchProducts(Long userId, String keyword, Long lastProductId, int limit,
+                                        String sort, String category);
 
     // 상품 추가
     ProductAddResponseDto addProduct(ProductAddRequestDto requestDto);

--- a/src/main/java/org/example/fanzip/market/service/MarketService.java
+++ b/src/main/java/org/example/fanzip/market/service/MarketService.java
@@ -8,17 +8,15 @@ import org.example.fanzip.market.dto.ProductListDto;
 import java.util.List;
 
 public interface MarketService {
-    // 최초 또는 전체 상품 목록 조회
-    List<ProductListDto> getAllProducts(int limit);
-
     // 마지막으로 가져온 상품 이후 목록 조회 (커서 페이징)
-    List<ProductListDto> getProductsAfter(Long lastProductId, int limit);
+    List<ProductListDto> getProducts(Long userId, Long lastProductId, int limit,
+                                     String sort, String category, boolean onlySubscribed);
 
     // 상세 상품 조회
     ProductDetailDto getProductDetail(Long userId, Long productId);
 
     // 검색
-    List<ProductListDto> searchProducts(String keyword, Long lastProductId, int limit);
+    List<ProductListDto> searchProducts(Long userId, String keyword, Long lastProductId, int limit);
 
     // 상품 추가
     ProductAddResponseDto addProduct(ProductAddRequestDto requestDto);

--- a/src/main/java/org/example/fanzip/market/service/MarketServiceImpl.java
+++ b/src/main/java/org/example/fanzip/market/service/MarketServiceImpl.java
@@ -77,8 +77,8 @@ public class MarketServiceImpl implements MarketService {
     }
 
     @Override
-    public List<ProductListDto> searchProducts(Long userId, String keyword, Long lastProductId, int limit) {
-        return marketMapper.searchProducts(userId, keyword, lastProductId, limit);
+    public List<ProductListDto> searchProducts(Long userId, String keyword, Long lastProductId, int limit, String sort, String category) {
+        return marketMapper.searchProducts(userId, keyword, lastProductId, limit, sort, category);
     }
 
     @Override

--- a/src/main/java/org/example/fanzip/payment/service/PaymentApproveService.java
+++ b/src/main/java/org/example/fanzip/payment/service/PaymentApproveService.java
@@ -20,7 +20,7 @@ public class PaymentApproveService {
     private final PaymentRepository paymentRepository;
     private final PaymentRollbackService paymentRollbackService;
     private final PaymentValidator paymentValidator;
-    private final MarketOrderMapper marketOrderMapper;
+//    private final MarketOrderMapper marketOrderMapper;
 
     @Transactional
     public PaymentResponseDto approvePaymentById(Long paymentId) {
@@ -30,24 +30,24 @@ public class PaymentApproveService {
         }
         paymentValidator.validateStockAvailability(payments.getOrderId(), payments.getReservationId(), payments.getMembershipId()); // 결제 승인 시 재고 수량 검사 홤수
         // TODO : 주문 금액과 결제 요청 금액이 맞는지 로직 변경 필요
-//        BigDecimal expectedAmount = getExpectedAmountMock(payments);
-//        if (payments.getAmount().compareTo(expectedAmount) != 0)  {
-//            throw new BusinessException(PaymentErrorCode.AMOUNT_MISMATCH);
-//        }
-
-        // 주문 금액으로 검증 (ORDERS)
-        BigDecimal expectedAmount;
-        if (payments.getOrderId() != null) {
-            Map<String, Object> row = marketOrderMapper.selectOrderForPayment(payments.getOrderId());
-            if (row == null) throw new BusinessException(PaymentErrorCode.ORDER_NOT_FOUND);
-            expectedAmount = (BigDecimal) row.get("finalAmount");
-        } else {
-            throw new BusinessException(PaymentErrorCode.UNSUPPORTED_PAYMENT_TYPE);
+        BigDecimal expectedAmount = getExpectedAmountMock(payments);
+        if (payments.getAmount().compareTo(expectedAmount) != 0)  {
+            throw new BusinessException(PaymentErrorCode.AMOUNT_MISMATCH);
         }
 
-        // 금액 검증
-        if (payments.getAmount().compareTo(expectedAmount) != 0)
-            throw new BusinessException(PaymentErrorCode.AMOUNT_MISMATCH);
+        // 주문 금액으로 검증 (ORDERS)
+//        BigDecimal expectedAmount;
+//        if (payments.getOrderId() != null) {
+//            Map<String, Object> row = marketOrderMapper.selectOrderForPayment(payments.getOrderId());
+//            if (row == null) throw new BusinessException(PaymentErrorCode.ORDER_NOT_FOUND);
+//            expectedAmount = (BigDecimal) row.get("finalAmount");
+//        } else {
+//            throw new BusinessException(PaymentErrorCode.UNSUPPORTED_PAYMENT_TYPE);
+//        }
+//
+//        // 금액 검증
+//        if (payments.getAmount().compareTo(expectedAmount) != 0)
+//            throw new BusinessException(PaymentErrorCode.AMOUNT_MISMATCH);
 
 
         payments.approve();

--- a/src/main/resources/org/example/fanzip/market/mapper/MarketMapper.xml
+++ b/src/main/resources/org/example/fanzip/market/mapper/MarketMapper.xml
@@ -4,52 +4,86 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.example.fanzip.market.mapper.MarketMapper">
 
-    <!-- limit 개수만큼 최신 상품 조회 (1페이지) -->
-    <select id="getAllProducts"
-            resultType="org.example.fanzip.market.dto.ProductListDto"
-            parameterType="int">
-        select
-            product_id          as productId,
-            name,
-            price,
-            discounted_price    as discountedPrice,
-            discount_rate       as discountRate,
-            thumbnail_image     as thumbnailImage,
-            stock
-        from products
-        order by product_id DESC
-        LIMIT #{limit}
-    </select>
+
 
     <!-- lastProductId 이후 커서 페이징 -->
-    <select id="getProductsAfter"
+    <select id="getProducts"
             resultType="org.example.fanzip.market.dto.ProductListDto"
             parameterType="map">
-        select
-            product_id          as productId,
-            name,
-            price,
-            discounted_price    as discountedPrice,
-            discount_rate       as discountRate,
-            thumbnail_image     as thumbnailImage,
-            stock
-        FROM products
-        WHERE product_id &lt; #{lastProductId}
-        ORDER BY product_id DESC
+        SELECT
+            p.product_id        AS productId,
+            p.name,
+            p.price,
+            p.discounted_price  AS discountedPrice,
+            p.discount_rate     AS discountRate,
+            p.thumbnail_image   AS thumbnailImage,
+            p.stock,
+            p.categories,
+            CASE WHEN ms.user_id IS NOT NULL THEN 1 ELSE 0 END AS subscribed,
+            IFNULL(ms.grade_id, 0)   as gradeId,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM (
+                         SELECT DISTINCT i2.category
+                         FROM memberships m2
+                         JOIN influencers i2 ON i2.influencer_id = m2.influencer_id
+                         WHERE m2.user_id = #{userId}
+                           AND m2.status = 'ACTIVE'
+                ) sic
+                WHERE sic.category = i.category
+            ) THEN 1 ELSE 0 END AS sameInfCategory,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM JSON_TABLE(p.categories, '$[*]'
+                                COLUMNS(cat VARCHAR(50) PATH '$')) pc
+                JOIN (
+                    SELECT DISTINCT jt.cat
+                    FROM products sp
+                             JOIN memberships m3
+                                  ON m3.influencer_id = sp.influencer_id
+                                      AND m3.user_id = #{userId}
+                                      AND m3.status = 'ACTIVE'
+                             JOIN JSON_TABLE(sp.categories, '$[*]'
+                                             COLUMNS(cat VARCHAR(50) PATH '$')) jt
+                ) subpc ON subpc.cat = pc.cat
+            ) THEN 1 ELSE 0 END AS catMatch
+        FROM products p
+        JOIN influencers i ON i.influencer_id = p.influencer_id
+        LEFT JOIN memberships ms
+             ON ms.influencer_id = p.influencer_id
+             AND ms.user_id = #{userId}
+             AND ms.status = 'ACTIVE'
+        <where>
+            <if test="lastProductId != null">
+                p.product_id &lt; #{lastProductId}
+            </if>
+            <if test="category != null and category != ''">
+                <if test="lastProductId != null"> AND </if>
+                JSON_CONTAINS(p.categories, JSON_QUOTE(#{category}), '$')
+            </if>
+            <if test="onlySubscribed">
+                <if test="lastProductId != null or (category != null and category != '')"> AND </if>
+                ms.user_id IS NOT NULL
+            </if>
+        </where>
+        <choose>
+            <when test="sort == 'latest'">
+                ORDER BY p.product_id DESC
+            </when>
+            <when test="sort == 'priceAsc'">
+                ORDER BY p.discounted_price ASC, p.product_id DESC
+            </when>
+            <otherwise>
+            ORDER BY
+                subscribed DESC,
+                gradeId DESC,
+                sameInfCategory DESC,
+                catMatch DESC,
+                p.product_id DESC
+            </otherwise>
+        </choose>
         LIMIT #{limit}
     </select>
-
-<!--    &lt;!&ndash; 내등급 확인 &ndash;&gt;-->
-<!--    <select id="findMyGrade"-->
-<!--            resultType="java.lang.Integer"-->
-<!--            parameterType="map">-->
-<!--        select grade_id  as gradeId-->
-<!--        from memberships-->
-<!--        where user_id = #{userId}-->
-<!--          and influencer_id = #{influencerId}-->
-<!--          and status = 'ACTIVE'-->
-<!--        limit 1-->
-<!--    </select>-->
 
     <!-- 상세 상품 내역 조회 -->
     <select id="findProductById"
@@ -67,7 +101,7 @@
             p.thumbnail_image       as thumbnailImage,
             p.detail_images         as detailImages,
             p.description_images    as descriptionImages,
-            ifnull(m.grade_id, 0)              as gradeId,
+            p.categories            as categories,
             case m.grade_id
                 when 1 then p.white_open_time
                 when 2 then p.silver_open_time
@@ -91,41 +125,65 @@
         where p.product_id = #{productId}
     </select>
 
-    <!-- 검색(1페이지) -->
+     <!-- 검색(중간페이지) -->
     <select id="searchProducts"
             parameterType="map"
             resultType="org.example.fanzip.market.dto.ProductListDto">
-        select
-            product_id          as productId,
-            name,
-            price,
-            discounted_price    as discountedPrice,
-            discount_rate       as discountRate,
-            thumbnail_image     as thumbnailImage,
-            stock
-        from products
-        where name LIKE CONCAT('%', #{keyword}, '%')
-        order by product_id desc
-        limit #{limit}
-    </select>
-
-    <!-- 검색(중간페이지) -->
-    <select id="searchProductsAfter"
-            parameterType="map"
-            resultType="org.example.fanzip.market.dto.ProductListDto">
-        select
-            product_id          as productId,
-            name,
-            price,
-            discounted_price    as discountedPrice,
-            discount_rate       as discountRate,
-            thumbnail_image     as thumbnailImage,
-            stock
-        from products
-        where product_id &lt; #{lastProductId}
-          and name LIKE CONCAT('%', #{keyword}, '%')
-        order by product_id desc
-        limit #{limit}
+        SELECT
+            p.product_id        AS productId,
+            p.name,
+            p.price,
+            p.discounted_price  AS discountedPrice,
+            p.discount_rate     AS discountRate,
+            p.thumbnail_image   AS thumbnailImage,
+            p.stock,
+            p.categories,
+            CASE WHEN ms.user_id IS NOT NULL THEN 1 ELSE 0 END AS subscribed,
+            IFNULL(ms.grade_id, 0)   as gradeId,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM (
+                         SELECT DISTINCT i2.category
+                         FROM memberships m2
+                                  JOIN influencers i2 ON i2.influencer_id = m2.influencer_id
+                         WHERE m2.user_id = #{userId}
+                           AND m2.status = 'ACTIVE'
+                     ) sic
+                WHERE sic.category = i.category
+            ) THEN 1 ELSE 0 END AS sameInfCategory,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM JSON_TABLE(p.categories, '$[*]'
+                                COLUMNS(cat VARCHAR(50) PATH '$')) pc
+                         JOIN (
+                    SELECT DISTINCT jt.cat
+                    FROM products sp
+                             JOIN memberships m3
+                                  ON m3.influencer_id = sp.influencer_id
+                                      AND m3.user_id = #{userId}
+                                      AND m3.status = 'ACTIVE'
+                             JOIN JSON_TABLE(sp.categories, '$[*]'
+                                             COLUMNS(cat VARCHAR(50) PATH '$')) jt
+                ) subpc ON subpc.cat = pc.cat
+            ) THEN 1 ELSE 0 END AS catMatch
+        FROM products p
+                 JOIN influencers i ON i.influencer_id = p.influencer_id
+                 LEFT JOIN memberships ms
+                           ON ms.influencer_id = p.influencer_id
+                               AND ms.user_id = #{userId}
+                               AND ms.status = 'ACTIVE'
+        <where>
+            p.name LIKE CONCAT('%', #{keyword}, '%')
+            <if test="lastProductId != null">
+                AND p.product_id &lt; #{lastProductId}
+            </if>
+        </where>
+        ORDER BY
+            subscribed DESC,
+            sameInfCategory DESC,
+            catMatch DESC,
+            p.product_id DESC
+        LIMIT #{limit}
     </select>
 
     <!-- 재고 조회 -->

--- a/src/main/resources/org/example/fanzip/market/mapper/MarketMapper.xml
+++ b/src/main/resources/org/example/fanzip/market/mapper/MarketMapper.xml
@@ -4,9 +4,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.example.fanzip.market.mapper.MarketMapper">
 
-
-
-    <!-- lastProductId 이후 커서 페이징 -->
+    <!-- 상품 조회 -->
     <select id="getProducts"
             resultType="org.example.fanzip.market.dto.ProductListDto"
             parameterType="map">
@@ -67,6 +65,9 @@
             </if>
         </where>
         <choose>
+            <when test="onlySubscribed">
+                ORDER BY gradeId DESC, p.product_id DESC
+            </when>
             <when test="sort == 'latest'">
                 ORDER BY p.product_id DESC
             </when>
@@ -125,7 +126,7 @@
         where p.product_id = #{productId}
     </select>
 
-     <!-- 검색(중간페이지) -->
+     <!-- 검색 -->
     <select id="searchProducts"
             parameterType="map"
             resultType="org.example.fanzip.market.dto.ProductListDto">
@@ -177,12 +178,26 @@
             <if test="lastProductId != null">
                 AND p.product_id &lt; #{lastProductId}
             </if>
+            <if test="category != null and category != ''">
+                AND JSON_CONTAINS(p.categories, JSON_QUOTE(#{category}), '$')
+            </if>
         </where>
-        ORDER BY
-            subscribed DESC,
-            sameInfCategory DESC,
-            catMatch DESC,
-            p.product_id DESC
+        <choose>
+            <when test="sort == 'latest'">
+                ORDER BY p.product_id DESC
+            </when>
+            <when test="sort == 'priceAsc'">
+                ORDER BY p.discounted_price ASC, p.product_id DESC
+            </when>
+            <otherwise>
+                ORDER BY
+                subscribed DESC,
+                gradeId DESC,
+                sameInfCategory DESC,
+                catMatch DESC,
+                p.product_id DESC
+            </otherwise>
+        </choose>
         LIMIT #{limit}
     </select>
 

--- a/src/test/java/org/example/fanzip/market/mapper/MarketMapperTest.java
+++ b/src/test/java/org/example/fanzip/market/mapper/MarketMapperTest.java
@@ -28,26 +28,14 @@ class MarketMapperTest {
     private MarketMapper marketMapper;
 
     @Test
-    void getAllProducts() {
-        List<ProductListDto> list = marketMapper.getAllProducts(10);
+    void getProducts() {
+        List<ProductListDto> list = marketMapper.getProducts(1L,null, 20, "priceAsc", "FOOD", false);
         assertNotNull(list, "상품 목록 not null");
         for(ProductListDto dto : list) {
             assertNotNull(dto.getProductId(), "productID not null");
             assertNotNull(dto.getName(), "상품명 not null");
-            log.info("getAllProducts: {}", dto);
+            log.info("=========getProducts=============: {}", dto);
         }
-    }
-
-    @Test
-    void getProductsAfter() {
-        List<ProductListDto> list = marketMapper.getProductsAfter(40L, 20);
-        assertNotNull(list, "상품 목록 not null");
-        for(ProductListDto dto : list) {
-            assertNotNull(dto.getProductId(), "productID not null");
-            assertNotNull(dto.getName(), "상품명 not null");
-            log.info("getProductsAfter: {}", dto);
-        }
-
     }
 
     @Test
@@ -57,18 +45,10 @@ class MarketMapperTest {
         log.info("=========> findProductById: {}", dto);
     }
 
-    @Test
-    void searchProducts() {
-        List<ProductListDto> list = marketMapper.searchProducts("00", 20);
-        for(ProductListDto dto : list) {
-            assertNotNull(dto.getProductId(), "productID not null");
-            log.info("searchProducts: {}", dto);
-        }
-    }
 
     @Test
-    void searchProductsAfter() {
-        List<ProductListDto> list = marketMapper.searchProductsAfter("상품", 20L, 8);
+    void searchProducts() {
+        List<ProductListDto> list = marketMapper.searchProducts(1L,"상품", 20L, 8);
         for(ProductListDto dto : list) {
             assertNotNull(dto.getProductId(), "productID not null");
             log.info("searchProductsAfter: {}", dto);

--- a/src/test/java/org/example/fanzip/market/mapper/MarketMapperTest.java
+++ b/src/test/java/org/example/fanzip/market/mapper/MarketMapperTest.java
@@ -48,7 +48,7 @@ class MarketMapperTest {
 
     @Test
     void searchProducts() {
-        List<ProductListDto> list = marketMapper.searchProducts(1L,"상품", 20L, 8);
+        List<ProductListDto> list = marketMapper.searchProducts(1L,"상품", 20L, 8, "priceAsc", "FOOD");
         for(ProductListDto dto : list) {
             assertNotNull(dto.getProductId(), "productID not null");
             log.info("searchProductsAfter: {}", dto);

--- a/src/test/java/org/example/fanzip/market/service/MarketServiceImplTest.java
+++ b/src/test/java/org/example/fanzip/market/service/MarketServiceImplTest.java
@@ -41,7 +41,7 @@ class MarketServiceImplTest {
 
     @Test
     void searchProducts() {
-        List<ProductListDto> list = marketService.searchProducts(1L,"상품", 30L, 20);
+        List<ProductListDto> list = marketService.searchProducts(1L,"상품", 30L, 20, "priceAsc", "FOOD");
         for (ProductListDto dto : list) {
             log.info(dto.toString());
         }

--- a/src/test/java/org/example/fanzip/market/service/MarketServiceImplTest.java
+++ b/src/test/java/org/example/fanzip/market/service/MarketServiceImplTest.java
@@ -26,16 +26,8 @@ class MarketServiceImplTest {
     private MarketService marketService;
 
     @Test
-    void getAllProducts() {
-        List<ProductListDto> list = marketService.getAllProducts(10);
-        for (ProductListDto dto : list) {
-            log.info(dto.toString());
-        }
-    }
-
-    @Test
-    void getProductsAfter() {
-        List<ProductListDto> list = marketService.getProductsAfter(60L, 10);
+    void getProducts() {
+        List<ProductListDto> list = marketService.getProducts(1L,60L, 10, "latest", "FOOD", false);
         for (ProductListDto dto : list) {
             log.info(dto.toString());
         }
@@ -49,7 +41,7 @@ class MarketServiceImplTest {
 
     @Test
     void searchProducts() {
-        List<ProductListDto> list = marketService.searchProducts("상품", 30L, 20);
+        List<ProductListDto> list = marketService.searchProducts(1L,"상품", 30L, 20);
         for (ProductListDto dto : list) {
             log.info(dto.toString());
         }


### PR DESCRIPTION
## 🔘 Part

- [ ] FE
- [X] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용
- 페이지 상단 상품 추천 애니메이션 (구독한 인플루언서의 상품)
- 마켓 상품 정렬
- 정렬 기준
 1. 내가 구독한 인플루언서의 상품
 1-2. 등급이 높은 인플루언서의 상품 우선
 2. 내가 구독한 인플루언서와 동일한 카테고리에 있는 인플루언서의 상품
 3. 내가 구독한 인플루언서의 상품의 카테고리와 동일한 카테고리에 있는 상품
 4. 최신 등록된 상품
의 순서로 정렬됩니다.
- 마켓 상품 카테고리별 조회 
- 추천순 / 최신순 / 낮은 가격순 으로 정렬 가능

<br/>

## ➕ 이슈 링크

- Closes #112

<br/>

## 📸 이미지 첨부
- 디폴트 화면
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/59f4586c-7be9-470b-9218-646b645aba6d" />

- 카테고리 선택 가능
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/07fe3493-e325-4c6c-a07e-7a5ab08a2054" />

- 정렬 순서 선택 가능
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/d78cad3d-def9-40ab-88de-a9f6c81597ad" />

- 검색된 상품도 정렬 가능
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/0f09ec02-c44a-487a-b518-7afcaeab5ad9" />

- 검색된 상품이 없는 경우
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/dc51398c-36f1-4f3c-8a24-449bae5faeb1" />

<br/>

## 📬 전달 사항

- 상단의 추천 서비스는 자동으로 무한스크롤입니다. (영상 확인)

<br/>

