### PR TITLE
[feat] SecurityConfig.java에 카카오 경로 인증 없이 접근하게 변경

### DIFF
--- a/src/main/java/org/example/fanzip/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/fanzip/global/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(
                         "/resources/**",
                         "/api/auth/oauth/**",
+                        "/oauth/**",
                         "/api/auth/reissue/**",
                         "/api/user/register/**",
                             "/swagger-ui.html",


### PR DESCRIPTION
## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용
SecurityConfig.java에 카카오 경로 /OAuth 부분 인증 없이 접근하게 변경했습니다.

<br/>

## ➕ 이슈 링크

<br/>

## 📸 이미지 첨부

<br/>

## 📬 전달 사항

<br/>

## 🔧 앞으로의 과제
- 로그인 이후 로직 확인 할 예정