### PR TITLE
[Feature] 팬카드 상세 페이지 기능 개선 - 구독 취소 및 결제 히스토리

### DIFF
--- a/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/FancardDetailResponse.java
@@ -19,4 +19,5 @@ public class FancardDetailResponse {
     private InfluencerDto influencer;
     private MembershipDto membership;
     private List<BenefitDto> benefits;
+    private List<PaymentHistoryDto> paymentHistory;
 }

--- a/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/InfluencerDto.java
@@ -15,5 +15,6 @@ public class InfluencerDto {
     private String influencerName;
     private String category;
     private String profileImage;
+    private String fancardImage;
     private Boolean isVerified;
 }

--- a/src/main/java/org/example/fanzip/fancard/dto/response/PaymentHistoryDto.java
+++ b/src/main/java/org/example/fanzip/fancard/dto/response/PaymentHistoryDto.java
@@ -1,0 +1,25 @@
+package org.example.fanzip.fancard.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentHistoryDto {
+    private Long paymentId;
+    private String title;
+    private BigDecimal amount;
+    private LocalDateTime paidAt;
+    private String status;
+    private String paymentMethod;
+    private String description;
+    private Boolean bold;
+}

--- a/src/main/java/org/example/fanzip/fancard/mapper/FancardMapper.java
+++ b/src/main/java/org/example/fanzip/fancard/mapper/FancardMapper.java
@@ -6,6 +6,7 @@ import org.example.fanzip.fancard.domain.Fancard;
 import org.example.fanzip.fancard.dto.response.InfluencerDto;
 import org.example.fanzip.fancard.dto.response.MembershipDto;
 import org.example.fanzip.fancard.dto.response.MembershipGradeDto;
+import org.example.fanzip.fancard.dto.response.PaymentHistoryDto;
 
 import java.util.List;
 
@@ -43,4 +44,7 @@ public interface FancardMapper {
     MembershipGradeDto findMembershipGradeById(@Param("gradeId") Long gradeId);
     
     String findInfluencerNameByMembershipId(@Param("membershipId") Long membershipId);
+    
+    // 결제 히스토리 조회
+    List<PaymentHistoryDto> findPaymentHistoryByMembershipId(@Param("membershipId") Long membershipId);
 }

--- a/src/main/java/org/example/fanzip/fancard/service/FancardService.java
+++ b/src/main/java/org/example/fanzip/fancard/service/FancardService.java
@@ -6,6 +6,9 @@ import org.example.fanzip.fancard.dto.response.FancardDetailResponse;
 import org.example.fanzip.fancard.dto.response.FancardListWrapper;
 import org.example.fanzip.fancard.dto.response.QrCodeResponse;
 import org.example.fanzip.fancard.dto.response.QrCodeValidationResponse;
+import org.example.fanzip.fancard.dto.response.PaymentHistoryDto;
+
+import java.util.List;
 
 public interface FancardService {
     
@@ -18,4 +21,8 @@ public interface FancardService {
     QrCodeValidationResponse validateQrCode(QrCodeValidationRequest request);
     
     QrCodeResponse getMobileTicketData(Long userId, Long reservationId, Long seatId, Long meetingId);
+    
+    void createFancardForMembership(Long membershipId, Long influencerId);
+    
+    List<PaymentHistoryDto> getPaymentHistory(Long membershipId);
 }

--- a/src/main/java/org/example/fanzip/global/config/RootConfig.java
+++ b/src/main/java/org/example/fanzip/global/config/RootConfig.java
@@ -14,11 +14,13 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
 import javax.sql.DataSource;
 
 @Configuration
+@EnableTransactionManagement
 @PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
 @MapperScan(basePackages = {
         "org.example.fanzip.fancard.mapper",

--- a/src/main/java/org/example/fanzip/global/exception/payment/PaymentErrorCode.java
+++ b/src/main/java/org/example/fanzip/global/exception/payment/PaymentErrorCode.java
@@ -14,6 +14,8 @@ public enum PaymentErrorCode implements ErrorCode {
     ORDER_STOCK_UNAVAILABLE("STOCK_001", HttpStatus.CONFLICT, "상품 재고가 부족합니다."),
     SEATS_UNAVAILABLE("STOCK_002", HttpStatus.CONFLICT, "예약 가능한 인원이 없습니다."),
     MEMBERSHIP_NOT_FOUND("MEMBERSHIP_001", HttpStatus.NOT_FOUND, "멤버십 가입 정보를 찾을 수 없습니다."),
+    MEMBERSHIP_ACTIVATION_FAILED("MEMBERSHIP_002", HttpStatus.INTERNAL_SERVER_ERROR, "멤버십 활성화에 실패했습니다."),
+    FANCARD_CREATION_FAILED("FANCARD_001", HttpStatus.INTERNAL_SERVER_ERROR, "팬카드 생성에 실패했습니다."),
     ORDER_NOT_FOUND("ORDER_001", HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다.");
 
     private final String code;

--- a/src/main/java/org/example/fanzip/membership/controller/MembershipController.java
+++ b/src/main/java/org/example/fanzip/membership/controller/MembershipController.java
@@ -64,5 +64,22 @@ public class MembershipController {
                 membershipService.getUserSubscriptionByInfluencer(userId, influencerId);
         return ResponseEntity.ok(subscription);
     }
+    
+    @DeleteMapping("/{membershipId}/cancel")
+    public ResponseEntity<String> cancelMembership(
+            @PathVariable Long membershipId,
+            Authentication authentication
+    ) {
+        CustomUserPrincipal principal = (CustomUserPrincipal) authentication.getPrincipal();
+        Long userId = principal.getUserId();
+        
+        boolean success = membershipService.cancelMembership(membershipId, userId);
+        
+        if (success) {
+            return ResponseEntity.ok("구독이 취소되었습니다.");
+        } else {
+            return ResponseEntity.badRequest().body("구독 취소에 실패했습니다.");
+        }
+    }
 
 }

--- a/src/main/java/org/example/fanzip/membership/mapper/MembershipMapper.java
+++ b/src/main/java/org/example/fanzip/membership/mapper/MembershipMapper.java
@@ -46,4 +46,12 @@
                             @Param("influencerId") long influencerId,
                             @Param("gradeId") int gradeId,
                             @Param("amount") BigDecimal amount);
+
+        int updateToActive(@Param("membershipId") long membershipId);
+        
+        MembershipVO findByMembershipId(@Param("membershipId") long membershipId);
+        
+        int updateTotalPaidAmount(@Param("membershipId") long membershipId, @Param("amount") BigDecimal amount);
+        
+        int cancelMembership(@Param("membershipId") long membershipId, @Param("userId") long userId);
     }

--- a/src/main/java/org/example/fanzip/membership/service/MembershipService.java
+++ b/src/main/java/org/example/fanzip/membership/service/MembershipService.java
@@ -27,4 +27,6 @@ public interface MembershipService{
     UserMembershipInfoDTO getUserMembershipInfo(Long userId);
 
     UserMembershipInfoDTO.UserMembershipSubscriptionDTO getUserSubscriptionByInfluencer(Long userId, Long influencerId);
+    
+    boolean cancelMembership(Long membershipId, Long userId);
 }

--- a/src/main/java/org/example/fanzip/membership/service/MembershipServiceImpl.java
+++ b/src/main/java/org/example/fanzip/membership/service/MembershipServiceImpl.java
@@ -128,4 +128,25 @@ public class MembershipServiceImpl implements MembershipService {
     public UserMembershipInfoDTO.UserMembershipSubscriptionDTO getUserSubscriptionByInfluencer(Long userId, Long influencerId) {
         return membershipMapper.findUserSubscriptionByInfluencerId(userId, influencerId);
     }
+    
+    @Override
+    @Transactional
+    public boolean cancelMembership(Long membershipId, Long userId) {
+        try {
+            // 구독 취소 실행
+            int result = membershipMapper.cancelMembership(membershipId, userId);
+            
+            if (result > 0) {
+                System.out.println("구독 취소 성공: membershipId=" + membershipId + ", userId=" + userId);
+                return true;
+            } else {
+                System.err.println("구독 취소 실패: membershipId=" + membershipId + ", userId=" + userId + " (해당 가능한 멤버십이 없음)");
+                return false;
+            }
+        } catch (Exception e) {
+            System.err.println("구독 취소 중 오류 발생: membershipId=" + membershipId + ", userId=" + userId + ", error=" + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
 }

--- a/src/main/java/org/example/fanzip/payment/service/PaymentApproveService.java
+++ b/src/main/java/org/example/fanzip/payment/service/PaymentApproveService.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.fanzip.global.exception.BusinessException;
 import org.example.fanzip.global.exception.payment.PaymentErrorCode;
 import org.example.fanzip.market.mapper.MarketOrderMapper;
+import org.example.fanzip.membership.mapper.MembershipMapper;
+import org.example.fanzip.membership.domain.MembershipVO;
+import org.example.fanzip.fancard.service.FancardService;
 import org.example.fanzip.payment.domain.Payments;
 import org.example.fanzip.payment.domain.enums.PaymentStatus;
+import org.example.fanzip.payment.domain.enums.PaymentType;
 import org.example.fanzip.payment.dto.PaymentResponseDto;
 import org.example.fanzip.payment.repository.PaymentRepository;
 import org.springframework.stereotype.Service;
@@ -20,6 +24,8 @@ public class PaymentApproveService {
     private final PaymentRepository paymentRepository;
     private final PaymentRollbackService paymentRollbackService;
     private final PaymentValidator paymentValidator;
+    private final MembershipMapper membershipMapper;
+    private final FancardService fancardService;
 //    private final MarketOrderMapper marketOrderMapper;
 
     @Transactional
@@ -52,10 +58,40 @@ public class PaymentApproveService {
 
         payments.approve();
         paymentRepository.updateStatus(payments);
-//        if(true) throw new RuntimeException("강제 예외");
-        /*  TODO: 멤버십 생성 or 갱신 로직 (Memberships 테이블 생기면 구현
-        if (payments.getPaymentType() == PaymentType.MEMBERSHIP) {
-         */
+
+        // 멤버십 결제 승인 시 추가 처리
+        if (payments.getPaymentType() == PaymentType.MEMBERSHIP && payments.getMembershipId() != null) {
+            // 1. 멤버십을 ACTIVE 상태로 변경
+            int updateResult = membershipMapper.updateToActive(payments.getMembershipId());
+            if (updateResult == 0) {
+                throw new BusinessException(PaymentErrorCode.MEMBERSHIP_ACTIVATION_FAILED);
+            }
+            System.out.println("멤버십 상태를 ACTIVE로 변경: membershipId=" + payments.getMembershipId());
+
+            // 2. 멤버십 정보 조회하여 인플루언서 ID 확인
+            MembershipVO membership = membershipMapper.findByMembershipId(payments.getMembershipId());
+            if (membership == null) {
+                throw new BusinessException(PaymentErrorCode.MEMBERSHIP_NOT_FOUND);
+            }
+
+            // 3. 총 납입 금액 업데이트
+            int updateAmountResult = membershipMapper.updateTotalPaidAmount(payments.getMembershipId(), payments.getAmount());
+            if (updateAmountResult == 0) {
+                System.err.println("총 납입 금액 업데이트 실패: membershipId=" + payments.getMembershipId());
+            } else {
+                System.out.println("총 납입 금액 업데이트 완료: membershipId=" + payments.getMembershipId() + ", amount=" + payments.getAmount());
+            }
+
+            // 4. 팬카드 자동 생성 (실패 시 예외 전파로 전체 트랜잭션 롤백)
+            try {
+                fancardService.createFancardForMembership(payments.getMembershipId(), membership.getInfluencerId());
+                System.out.println("팬카드 생성 완료: membershipId=" + payments.getMembershipId());
+            } catch (RuntimeException e) {
+                System.err.println("팬카드 생성 실패: membershipId=" + payments.getMembershipId() + ", error=" + e.getMessage());
+                throw new BusinessException(PaymentErrorCode.FANCARD_CREATION_FAILED);
+            }
+        }
+
         return PaymentResponseDto.from(payments);
     }
 
@@ -87,7 +123,16 @@ public class PaymentApproveService {
             return new BigDecimal("12000"); // 예매 금액 mock
         }
         if (payments.getMembershipId() != null) {
-            return new BigDecimal("10000"); // 멤버십 월 구독료 mock
+            try {
+                // 실제 멤버십 금액 조회
+                BigDecimal actualAmount = membershipMapper.findMonthlyAmountByGradeId(
+                    membershipMapper.findByMembershipId(payments.getMembershipId()).getGradeId()
+                );
+                return actualAmount != null ? actualAmount : new BigDecimal("10000"); // fallback
+            } catch (Exception e) {
+                System.err.println("멤버십 금액 조회 실패, 기본값 사용: " + e.getMessage());
+                return new BigDecimal("10000"); // fallback
+            }
         }
         throw new BusinessException(PaymentErrorCode.UNSUPPORTED_PAYMENT_TYPE);
     }

--- a/src/main/resources/mappers/FancardMapper.xml
+++ b/src/main/resources/mappers/FancardMapper.xml
@@ -104,12 +104,13 @@
         <result property="influencerName" column="influencer_name"/>
         <result property="category" column="category"/>
         <result property="profileImage" column="profile_image"/>
+        <result property="fancardImage" column="fancard_image"/>
         <result property="isVerified" column="is_verified"/>
     </resultMap>
 
     <!-- 멤버십 ID로 인플루언서 정보 조회 -->
     <select id="findInfluencerByMembershipId" parameterType="long" resultMap="influencerDtoResultMap">
-        SELECT i.influencer_id, i.influencer_name, i.category, i.profile_image, i.is_verified
+        SELECT i.influencer_id, i.influencer_name, i.category, i.profile_image, i.fancard_image, i.is_verified
         FROM influencers i
         JOIN memberships m ON i.influencer_id = m.influencer_id
         WHERE m.membership_id = #{membershipId}
@@ -157,6 +158,48 @@
         FROM influencers i
         JOIN memberships m ON i.influencer_id = m.influencer_id
         WHERE m.membership_id = #{membershipId}
+    </select>
+    
+    <!-- PaymentHistoryDto ResultMap -->
+    <resultMap id="paymentHistoryDtoResultMap" type="org.example.fanzip.fancard.dto.response.PaymentHistoryDto">
+        <id property="paymentId" column="payment_id"/>
+        <result property="title" column="title"/>
+        <result property="amount" column="amount"/>
+        <result property="paidAt" column="paid_at"/>
+        <result property="status" column="status"/>
+        <result property="paymentMethod" column="payment_method"/>
+        <result property="description" column="description"/>
+        <result property="bold" column="bold"/>
+    </resultMap>
+
+    <!-- 멤버십 ID로 결제 히스토리 조회 -->
+    <select id="findPaymentHistoryByMembershipId" parameterType="long" resultMap="paymentHistoryDtoResultMap">
+        SELECT 
+            p.payment_id,
+            CASE 
+                WHEN p.payment_type = 'MEMBERSHIP' THEN CONCAT(i.influencer_name, ' 멤버십 구독')
+                ELSE '기타 결제'
+            END as title,
+            p.amount,
+            p.paid_at,
+            p.status,
+            p.payment_method,
+            CASE 
+                WHEN p.payment_type = 'MEMBERSHIP' THEN CONCAT('등급: ', mg.grade_name)
+                ELSE ''
+            END as description,
+            CASE 
+                WHEN p.status IN ('APPROVED', 'PAID') THEN true
+                ELSE false
+            END as bold
+        FROM payments p
+        JOIN memberships m ON p.membership_id = m.membership_id
+        JOIN influencers i ON m.influencer_id = i.influencer_id
+        LEFT JOIN membership_grades mg ON m.grade_id = mg.grade_id
+        WHERE p.membership_id = #{membershipId}
+        AND p.status IN ('APPROVED', 'PAID')
+        ORDER BY p.paid_at DESC
+        LIMIT 20
     </select>
 
 </mapper>

--- a/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
+++ b/src/main/resources/org/example/fanzip/influencer/mapper/InfluencerMapper.xml
@@ -37,6 +37,8 @@
             SELECT influencer_id
             FROM memberships
             WHERE user_id = #{userId}
+            AND status = 'ACTIVE'
+            AND subscription_end >= CURDATE()
             )
 
             <if test="category != null">

--- a/src/main/resources/org/example/fanzip/membership/mapper/MembershipMapper.xml
+++ b/src/main/resources/org/example/fanzip/membership/mapper/MembershipMapper.xml
@@ -166,4 +166,38 @@
           AND influencer_id = #{influencerId}
     </update>
 
+    <!-- 결제 완료 시 ACTIVE로 변경 -->
+    <update id="updateToActive">
+        UPDATE memberships
+        SET status = 'ACTIVE',
+            subscription_start = NOW(),
+            subscription_end = DATE_ADD(NOW(), INTERVAL 1 MONTH)
+        WHERE membership_id = #{membershipId}
+    </update>
+
+    <!-- 멤버십 ID로 멤버십 조회 -->
+    <select id="findByMembershipId" resultMap="membershipMap">
+        SELECT *
+        FROM memberships
+        WHERE membership_id = #{membershipId}
+    </select>
+    
+    <!-- 총 납입 금액 업데이트 -->
+    <update id="updateTotalPaidAmount">
+        UPDATE memberships 
+        SET total_paid_amount = IFNULL(total_paid_amount, 0) + #{amount}
+        WHERE membership_id = #{membershipId}
+    </update>
+    
+    <!-- 구독 취소 -->
+    <update id="cancelMembership">
+        UPDATE memberships 
+        SET status = 'CANCELLED',
+            subscription_end = NOW(),
+            auto_renewal = false
+        WHERE membership_id = #{membershipId}
+        AND user_id = #{userId}
+        AND status = 'ACTIVE'
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 🔘 Part

- [ ] FE
- [x] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용
  - 팬카드 상세 페이지에 결제 히스토리("추억") 기능 추가
  - 멤버십 구독 취소 API 구현
  - 결제 상태별 히스토리 조회 개선

<br/>

## ➕ 이슈 링크


<br/>

## 📸 이미지 첨부
결제 완료 알림
<img width="428" height="926" alt="image" src="https://github.com/user-attachments/assets/7ced0cb5-2bf9-439d-9be3-61c78317e94c" />


구독 취소 로직
<img width="445" height="1055" alt="image" src="https://github.com/user-attachments/assets/30fca83c-f213-42c7-8298-a70bd6a485f3" />



<br/>

## 📬 전달 사항
 - 팬 카드 5장 밑일 때 로직이 좀 이상한 것 같아 수정이 필요해보임.

<br/>

## 🔧 앞으로의 과제
