### PR TITLE
[ifx] 미 커밋된 부분 추가

### DIFF
--- a/src/main/java/org/example/fanzip/meeting/controller/FanMeetingReservationController.java
+++ b/src/main/java/org/example/fanzip/meeting/controller/FanMeetingReservationController.java
@@ -80,4 +80,14 @@ public class FanMeetingReservationController {
 
         return ResponseEntity.ok(reservationService.startPayment(meetingId, seatId, userId));
     }
+
+    @GetMapping("/{meetingId}/pending-seats")
+    public List<FanMeetingSeatResponseDTO> getPendingSeats(
+            @PathVariable Long meetingId,
+            Authentication authentication) {
+        CustomUserPrincipal principal = (CustomUserPrincipal) authentication.getPrincipal();
+        Long userId = principal.getUserId();
+
+        return reservationService.getPendingSeats(meetingId, userId);
+    }
 }

--- a/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationService.java
+++ b/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationService.java
@@ -1,7 +1,10 @@
 package org.example.fanzip.meeting.service;
 
 import org.example.fanzip.meeting.dto.FanMeetingReservationResponseDTO;
+import org.example.fanzip.meeting.dto.FanMeetingSeatResponseDTO;
 import org.example.fanzip.meeting.dto.PaymentIntentResponseDTO;
+
+import java.util.List;
 
 public interface FanMeetingReservationService {
     FanMeetingReservationResponseDTO reserveSeat(Long meetingId, Long seatId, Long userId);
@@ -10,4 +13,5 @@ public interface FanMeetingReservationService {
     PaymentIntentResponseDTO startPayment(Long meetingId, Long seatId, Long userId);
     void confirmByPaymentId(Long paymentId);  // 결제 승인 콜백에서 호출
     void cancelByPaymentId(Long paymentId);
+    List<FanMeetingSeatResponseDTO> getPendingSeats(Long meetingId, Long userId);
 }

--- a/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationServiceImpl.java
+++ b/src/main/java/org/example/fanzip/meeting/service/FanMeetingReservationServiceImpl.java
@@ -310,7 +310,6 @@ public class FanMeetingReservationServiceImpl implements FanMeetingReservationSe
                 dto.setSeatNumber(seat.getSeatNumber());
                 dto.setPrice(seat.getPrice());
                 dto.setReserved(true); // PENDING 상태도 예약된 것으로 표시
-                dto.setGrade(seat.getGrade());
                 pendingSeats.add(dto);
             }
         }

--- a/src/main/java/org/example/fanzip/meeting/service/FanMeetingServiceImpl.java
+++ b/src/main/java/org/example/fanzip/meeting/service/FanMeetingServiceImpl.java
@@ -32,8 +32,6 @@ public class FanMeetingServiceImpl implements FanMeetingService {
     private final MembershipMapper membershipMapper;
     private final ApplicationEventPublisher publisher;
 
-    @Autowired
-    private FanMeetingSeatMapper seatMapper;
 
     @Override
     public List<FanMeetingResponseDTO> getOpenMeetings(String userGradeStr) {
@@ -106,7 +104,7 @@ public class FanMeetingServiceImpl implements FanMeetingService {
 
         // 좌석 자동 생성
         List<FanMeetingSeatVO> seats = generateSeats(meeting.getMeetingId());
-        seatMapper.insertSeatList(seats);
+        fanMeetingSeatMapper.insertSeatList(seats);
     }
 
     private List<FanMeetingSeatVO> generateSeats(Long meetingId) {


### PR DESCRIPTION
- 제목 : feat(#17): 회원 탈퇴 API 구현  
  ex) feat(#17): pull request template 작성  
  (확인 후 지워주세요)

## 🔘 Part

- [x] FE
- [ ] BE
- [ ] Docs
- [ ] Chore

<br/>

## 🔎 작업 내용

- 회원 탈퇴 API (`DELETE /auth/me`) 구현
- 탈퇴 시 is_active = false, deleted_at = now 처리
- 탈퇴 확인 alert 추가

<br/>

## ➕ 이슈 링크

- Closes #17

<br/>

## 📸 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 📬 전달 사항

- 탈퇴 처리 이후 access token은 바로 만료되지 않음 → 추후 개선 필요

<br/>

## 🔧 앞으로의 과제

- 비밀번호 확인 후 탈퇴 처리 기능 추가 예정